### PR TITLE
corrected some regexs

### DIFF
--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -126,7 +126,7 @@ end
 #
 ##############################################################################
 
-const NONLETTER_REGEX = Regex("[^a-zA-Z\s]", 0)
+const NONLETTER_REGEX = Regex("[^a-zA-Z\\s]", 0)
 #remove_nonletters(s::String) = replace(s, r"[^a-zA-Z]", "")
 remove_nonletters(s::String) = replace(s, NONLETTER_REGEX, "")
 
@@ -203,7 +203,7 @@ end
 #
 ##############################################################################
 
-const NUMBER_REGEX = Regex("\d+", 0)
+const NUMBER_REGEX = Regex("\\d+", 0)
 #remove_numbers(s::String) = replace(s, r"\d+", "")
 remove_numbers(s::String) = replace(s, NUMBER_REGEX, "")
 


### PR DESCRIPTION
Before:

```
julia> NONLETTER_REGEX = Regex("[^a-zA-Z\s]", 0)
Regex("[^a-zA-Zs]",0x00000000)

julia> matchall(NONLETTER_REGEX, "aaaa d123 bbb ccc 678 dddd")
11-element Array{SubString{UTF8String},1}:
 " "
 "1"
 "2"
 "3"
 " "
 " "
 " "
 "6"
 "7"
 "8"
 " "

julia> NUMBER_REGEX = Regex("\d+", 0)
Regex("d+",0x00000000)

julia> matchall(NUMBER_REGEX, "sunday 12")
1-element Array{SubString{UTF8String},1}:
 "d"
```

After:

```
julia> NONLETTER_REGEX = Regex("[^a-zA-Z\\s]", 0)
Regex("[^a-zA-Z\\s]",0x00000000)

julia> matchall(NONLETTER_REGEX, "aaaa d123 bbb ccc 678 dddd")
6-element Array{SubString{UTF8String},1}:
 "1"
 "2"
 "3"
 "6"
 "7"
 "8"

julia> NUMBER_REGEX = Regex("\\d+", 0)
Regex("\\d+",0x00000000)

julia> matchall(NUMBER_REGEX, "sunday 12")
1-element Array{SubString{UTF8String},1}:
 "12"
```
