### PR TITLE
optimizing preprocessing by combined regex

### DIFF
--- a/run_tests.jl
+++ b/run_tests.jl
@@ -4,7 +4,7 @@
 
 using TextAnalysis
 
-require("test.jl")
+#require("test.jl")
 
 my_tests = ["test/tokenizer.jl",
             "test/ngramizer.jl",

--- a/src/TextAnalysis.jl
+++ b/src/TextAnalysis.jl
@@ -31,6 +31,7 @@ module TextAnalysis
     export remove_definite_articles!, remove_indefinite_articles!
     export remove_prepositions, remove_pronouns, stem, tag_pos
     export remove_prepositions!, remove_pronouns!, stem!, tag_pos!
+    export prepare!
     export frequent_terms, sparse_terms
     export remove_frequent_terms!, remove_sparse_terms!
     export dtv, each_dtv, dtm, tdm
@@ -39,6 +40,10 @@ module TextAnalysis
     export standardize!
     export tf_idf, lsa, lda
     export tf_idf!, lsa!, lda!
+
+    export strip_patterns, strip_corrupt_utf8, strip_case, stem_words, tag_part_of_speech, strip_whitespace, strip_punctuation
+    export strip_numbers, strip_non_letters, strip_indefinite_articles, strip_definite_articles, strip_articles
+    export strip_prepositions, strip_pronouns, strip_stopwords, strip_sparse_terms, strip_frequent_terms
 
     include("tokenizer.jl")
     include("ngramizer.jl")

--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -1,9 +1,35 @@
+
+const strip_patterns                = uint32(0)
+const strip_corrupt_utf8            = uint32(0x1) << 0
+const strip_case                    = uint32(0x1) << 1
+const stem_words                    = uint32(0x1) << 2
+const tag_part_of_speech            = uint32(0x1) << 3
+
+const strip_whitespace              = uint32(0x1) << 5
+const strip_punctuation             = uint32(0x1) << 6
+const strip_numbers                 = uint32(0x1) << 7
+const strip_non_letters             = uint32(0x1) << 8
+
+const strip_indefinite_articles     = uint32(0x1) << 9
+const strip_definite_articles       = uint32(0x1) << 10
+const strip_articles                = (strip_indefinite_articles | strip_definite_articles)
+
+const strip_prepositions            = uint32(0x1) << 13
+const strip_pronouns                = uint32(0x1) << 14
+
+const strip_stopwords               = uint32(0x1) << 16
+const strip_sparse_terms            = uint32(0x1) << 17
+const strip_frequent_terms          = uint32(0x1) << 18
+
+const alpha_sparse      = 0.05
+const alpha_frequent    = 0.95
+
+
 ##############################################################################
 #
 # Remove corrupt UTF8 characters
 #
 ##############################################################################
-
 function remove_corrupt_utf8(s::String)
     r = Array(Char, endof(s))
     i = 0
@@ -17,11 +43,12 @@ function remove_corrupt_utf8(s::String)
 end
 
 function remove_corrupt_utf8!(d::FileDocument)
-    error("FileDocument's cannot be modified")
+    error("FileDocument cannot be modified")
 end
 
 function remove_corrupt_utf8!(d::StringDocument)
     d.text = remove_corrupt_utf8(d.text)
+    nothing
 end
 
 function remove_corrupt_utf8!(d::TokenDocument)
@@ -44,117 +71,9 @@ function remove_corrupt_utf8!(d::NGramDocument)
     end
 end
 
-##############################################################################
-#
-# Remove white space
-#
-##############################################################################
-
-const WHITESPACE_REGEX = Regex("\\s+", 0)
-#remove_whitespace(s::String) = replace(s, r"\s+", " ")
-remove_whitespace(s::String) = replace(s, WHITESPACE_REGEX, " ")
-
-function remove_whitespace!(d::FileDocument)
-    error("FileDocument's cannot be modified")
-end
-
-function remove_whitespace!(d::StringDocument)
-    d.text = remove_whitespace(d.text)
-end
-
-function remove_whitespace!(d::TokenDocument)
-    for i in 1:length(d.tokens)
-        d.tokens[i] = remove_whitespace(d.tokens[i])
-    end
-end
-
-function remove_whitespace!(d::NGramDocument)
-    for token in keys(d.ngrams)
-        new_token = remove_whitespace(token)
-        if new_token != token
-            if haskey(d.ngrams, new_token)
-                d.ngrams[new_token] = d.ngrams[new_token] + d.ngrams[token]
-            else
-                d.ngrams[new_token] = d.ngrams[token]
-            end
-            delete!(d.ngrams, token)
-        end
-    end
-end
-
-##############################################################################
-#
-# Remove punctuation
-#
-##############################################################################
-
-const PUNCTUATION_REGEX = Regex("[,;:.!?()]+", 0)
-#remove_punctuation(s::String) = replace(s, r"[,;:.!?()]+", "")
-remove_punctuation(s::String) = replace(s, PUNCTUATION_REGEX, "")
-
-function remove_punctuation!(d::FileDocument)
-    error("FileDocument's cannot be modified")
-end
-
-function remove_punctuation!(d::StringDocument)
-    d.text = remove_punctuation(d.text)
-end
-
-function remove_punctuation!(d::TokenDocument)
-    for i in 1:length(d.tokens)
-        d.tokens[i] = remove_punctuation(d.tokens[i])
-    end
-end
-
-function remove_punctuation!(d::NGramDocument)
-    for token in keys(d.ngrams)
-        new_token = remove_punctuation(token)
-        if new_token != token
-            if haskey(d.ngrams, new_token)
-                d.ngrams[new_token] = d.ngrams[new_token] + d.ngrams[token]
-            else
-                d.ngrams[new_token] = d.ngrams[token]
-            end
-            delete!(d.ngrams, token)
-        end
-    end
-end
-
-##############################################################################
-#
-# Remove non-letters
-#
-##############################################################################
-
-const NONLETTER_REGEX = Regex("[^a-zA-Z\\s]", 0)
-#remove_nonletters(s::String) = replace(s, r"[^a-zA-Z]", "")
-remove_nonletters(s::String) = replace(s, NONLETTER_REGEX, "")
-
-function remove_nonletters!(d::FileDocument)
-    error("FileDocument's cannot be modified")
-end
-
-function remove_nonletters!(d::StringDocument)
-    d.text = remove_nonletters(d.text)
-end
-
-function remove_nonletters!(d::TokenDocument)
-    for i in 1:length(d.tokens)
-        d.tokens[i] = remove_nonletters(d.tokens[i])
-    end
-end
-
-function remove_nonletters!(d::NGramDocument)
-    for token in keys(d.ngrams)
-        new_token = remove_nonletters(token)
-        if new_token != token
-            if haskey(d.ngrams, new_token)
-                d.ngrams[new_token] = d.ngrams[new_token] + d.ngrams[token]
-            else
-                d.ngrams[new_token] = d.ngrams[token]
-            end
-            delete!(d.ngrams, token)
-        end
+function remove_corrupt_utf8!(crps::Corpus)
+    for doc in crps
+        remove_corrupt_utf8!(doc)
     end
 end
 
@@ -167,11 +86,12 @@ end
 remove_case = lowercase
 
 function remove_case!(d::FileDocument)
-    error("FileDocument's cannot be modified")
+    error("FileDocument cannot be modified")
 end
 
 function remove_case!(d::StringDocument)
     d.text = remove_case(d.text)
+    nothing
 end
 
 function remove_case!(d::TokenDocument)
@@ -194,44 +114,9 @@ function remove_case!(d::NGramDocument)
     end
 end
 
-##############################################################################
-#
-# Remove numbers
-#
-# TODO: Currently removes all numeric characters.
-#       Should we just remove purely numeric tokens?
-#
-##############################################################################
-
-const NUMBER_REGEX = Regex("\\d+", 0)
-#remove_numbers(s::String) = replace(s, r"\d+", "")
-remove_numbers(s::String) = replace(s, NUMBER_REGEX, "")
-
-function remove_numbers!(d::FileDocument)
-    error("FileDocument's cannot be modified")
-end
-
-function remove_numbers!(d::StringDocument)
-      d.text = remove_numbers(d.text)
-end
-
-function remove_numbers!(d::TokenDocument)
-    for i in 1:length(d.tokens)
-        d.tokens[i] = remove_numbers(d.tokens[i])
-    end
-end
-
-function remove_numbers!(d::NGramDocument)
-    for token in keys(d.ngrams)
-        new_token = remove_numbers(token)
-        if new_token != token
-            if haskey(d.ngrams, new_token)
-                d.ngrams[new_token] = d.ngrams[new_token] + d.ngrams[token]
-            else
-                d.ngrams[new_token] = d.ngrams[token]
-            end
-            delete!(d.ngrams, token)
-        end
+function remove_case!(crps::Corpus)
+    for doc in crps
+        remove_case!(doc)
     end
 end
 
@@ -240,32 +125,182 @@ end
 # Remove specified words
 #
 ##############################################################################
+function remove_words!{T <: String}(entity::Union(AbstractDocument,Corpus), words::Vector{T})
+    skipwords = Set{String}()
+    union!(skipwords, words)
+    prepare!(entity, strip_patterns, skip_words = skipwords)
+end
 
-function remove_words{T <: String}(s::String, words::Vector{T})
-    for word in words
-        #s = replace(s, Regex(strcat("\\b", word, "\\b")), " ")
-        s = replace(s, Regex(string("\\b", word, "\\b"), 0), " ")
+function remove_whitespace!(entity::Union(AbstractDocument,Corpus)) 
+    Base.warn_once("remove_whitespace! is deprecated, Use prepare! instead.")
+    prepare!(entity, strip_whitespace)
+end
+function remove_punctuation!(entity::Union(AbstractDocument,Corpus)) 
+    Base.warn_once("remove_punctuation! is deprecated, Use prepare! instead.")
+    prepare!(entity, strip_punctuation)
+end
+function remove_nonletters!(entity::Union(AbstractDocument,Corpus)) 
+    Base.warn_once("remove_nonletters! is deprecated, Use prepare! instead.")
+    prepare!(entity, strip_non_letters)
+end
+function remove_numbers!(entity::Union(AbstractDocument,Corpus)) 
+    Base.warn_once("remove_numbers! is deprecated, Use prepare! instead.")
+    prepare!(entity, strip_numbers)
+end
+function remove_articles!(entity::Union(AbstractDocument,Corpus)) 
+    Base.warn_once("remove_articles! is deprecated, Use prepare! instead.")
+    prepare!(entity, strip_articles)
+end
+function remove_indefinite_articles!(entity::Union(AbstractDocument,Corpus)) 
+    Base.warn_once("remove_indefinite_articles! is deprecated, Use prepare! instead.")
+    prepare!(entity, strip_indefinite_articles)
+end
+function remove_definite_articles!(entity::Union(AbstractDocument,Corpus)) 
+    Base.warn_once("remove_definite_articles! is deprecated, Use prepare! instead.")
+    prepare!(entity, strip_definite_articles)
+end
+function remove_prepositions!(entity::Union(AbstractDocument,Corpus)) 
+    Base.warn_once("remove_prepositions! is deprecated, Use prepare! instead.")
+    prepare!(entity, strip_prepositions)
+end
+function remove_pronouns!(entity::Union(AbstractDocument,Corpus)) 
+    Base.warn_once("remove_pronouns! is deprecated, Use prepare! instead.")
+    prepare!(entity, strip_pronouns)
+end
+function remove_stop_words!(entity::Union(AbstractDocument,Corpus)) 
+    Base.warn_once("remove_stop_words! is deprecated, Use prepare! instead.")
+    prepare!(entity, strip_stopwords)
+end
+
+
+##############################################################################
+#
+# Stemming
+#
+##############################################################################
+
+stem!(entity) = error("Not yet implemented")
+
+##############################################################################
+#
+# Part-of-Speech tagging
+#
+##############################################################################
+
+tag_pos!(entity) = error("Not yet implemented")
+
+
+
+##############################################################################
+#
+# Drop terms based on frequency
+#
+##############################################################################
+
+function sparse_terms(crps::Corpus, alpha::Real = alpha_sparse)
+    update_lexicon!(crps)
+    update_inverse_index!(crps)
+    res = Array(UTF8String, 0)
+    ndocs = length(crps.documents)
+    for term in keys(crps.lexicon)
+        f = length(crps.inverse_index[term]) / ndocs
+        if f <= alpha
+            push!(res, term)
+        end
     end
-    return s
+    return res
 end
 
-function remove_words!(d::FileDocument)
-    error("FileDocument's cannot be modified")
+function frequent_terms(crps::Corpus, alpha::Real = alpha_frequent)
+    update_lexicon!(crps)
+    update_inverse_index!(crps)
+    res = Array(UTF8String, 0)
+    ndocs = length(crps.documents)
+    for term in keys(crps.lexicon)
+        f = length(crps.inverse_index[term]) / ndocs
+        if f >= alpha
+            push!(res, term)
+        end
+    end
+    return res
 end
 
-function remove_words!{T <: String}(d::StringDocument, words::Vector{T})
-    d.text = remove_words(d.text, words)
+# Sparse terms occur in less than x percent of all documents
+remove_sparse_terms!(crps::Corpus, alpha::Real = alpha_sparse) = remove_words!(crps, sparse_terms(crps, alpha))
+
+# Frequent terms occur in more than x percent of all documents
+remove_frequent_terms!(crps::Corpus, alpha::Real = alpha_frequent) = remove_words!(crps, frequent_terms(crps, alpha))
+
+
+
+##############################################################################
+#
+# Remove parts from document based on flags or regular expressions
+#
+##############################################################################
+
+function prepare!(crps::Corpus, flags::Uint32; skip_patterns = Set{String}(), skip_words = Set{String}())
+    ((flags & strip_sparse_terms) > 0) && union!(skip_words, sparse_terms(crps))
+    ((flags & strip_frequent_terms) > 0) && union!(skip_words, frequent_terms(crps))
+
+    ((flags & strip_corrupt_utf8) > 0) && remove_corrupt_utf8!(crps)
+    ((flags & strip_case) > 0) && remove_case!(crps)
+
+    lang = language(crps.documents[1])   # assuming all documents are of the same language - practically true
+    r = _build_regex(lang, flags, skip_patterns, skip_words)
+    !isempty(r.pattern) && remove_patterns!(crps, r)
+
+    ((flags & stem_words) > 0) && stem!(crps)
+    ((flags & tag_part_of_speech) > 0) && tag_pos!(crps)
+    nothing
 end
 
-function remove_words!{T <: String}(d::TokenDocument, words::Vector{T})
+function prepare!(d::AbstractDocument, flags::Uint32; skip_patterns = Set{String}(), skip_words = Set{String}()) 
+    ((flags & strip_corrupt_utf8) > 0) && remove_corrupt_utf8!(d)
+    ((flags & strip_case) > 0) && remove_case!(d)
+
+    r = _build_regex(language(d), flags, skip_patterns, skip_words)
+    !isempty(r.pattern) && remove_patterns!(d, r)
+
+    ((flags & stem_words) > 0) && stem!(d)
+    ((flags & tag_part_of_speech) > 0) && tag_pos!(d)
+    nothing
+end
+
+##
+# internal helper methods
+function remove_patterns(s::String, rex::Regex)
+    iob = IOBuffer()
+    ibegin = 1
+    for m in matchall(rex, s)
+        len = m.offset-ibegin+1
+        if len > 0
+            Base.write_sub(iob, s.data, ibegin, len)
+            write(iob, ' ')
+        end
+        ibegin = m.endof+m.offset+1
+    end
+    len = length(s.data) - ibegin + 1
+    (len > 0) && Base.write_sub(iob, s.data, ibegin, len)
+    takebuf_string(iob)
+end
+
+remove_patterns!(d::FileDocument, rex::Regex) = error("FileDocument cannot be modified")
+
+function remove_patterns!(d::StringDocument, rex::Regex)
+    d.text = remove_patterns(d.text, rex)
+    nothing
+end
+
+function remove_patterns!(d::TokenDocument, rex::Regex)
     for i in 1:length(d.tokens)
-        d.tokens[i] = remove_words(d.tokens[i], words)
+        d.tokens[i] = remove_patterns(d.tokens[i], rex)
     end
 end
 
-function remove_words!{T <: String}(d::NGramDocument, words::Vector{T})
+function remove_patterns!(d::NGramDocument, rex::Regex)
     for token in keys(d.ngrams)
-        new_token = remove_words(token, words)
+        new_token = remove_patterns(token, rex)
         if new_token != token
             if haskey(d.ngrams, new_token)
                 d.ngrams[new_token] = d.ngrams[new_token] + d.ngrams[token]
@@ -277,136 +312,63 @@ function remove_words!{T <: String}(d::NGramDocument, words::Vector{T})
     end
 end
 
-##############################################################################
-#
-# Remove articles, indefinite articles, definite articles,
-# prepositions, pronouns and stop words
-#
-##############################################################################
-
-function remove_articles!(d::AbstractDocument)
-    remove_words!(d, articles(language(d)))
-end
-
-function remove_indefinite_articles!(d::AbstractDocument)
-    remove_words!(d, indefinite_articles(language(d)))
-end
-
-function remove_definite_articles!(d::AbstractDocument)
-    remove_words!(d, definite_articles(language(d)))
-end
-
-function remove_prepositions!(d::AbstractDocument)
-    remove_words!(d, prepositions(language(d)))
-end
-
-function remove_pronouns!(d::AbstractDocument)
-    remove_words!(d, pronouns(language(d)))
-end
-
-function remove_stop_words!(d::AbstractDocument)
-    remove_words!(d, stopwords(language(d)))
-end
-
-##############################################################################
-#
-# Stemming
-#
-##############################################################################
-
-stem!(fd::AbstractDocument) = error("Not yet implemented")
-
-##############################################################################
-#
-# Part-of-Speech tagging
-#
-##############################################################################
-
-tag_pos!(fd::AbstractDocument) = error("Not yet implemented")
-
-##############################################################################
-#
-# Call preprocessing step on each document in a Corpus
-#
-##############################################################################
-
-for f in (:remove_whitespace!,
-          :remove_corrupt_utf8!,
-          :remove_punctuation!,
-          :remove_case!,
-          :remove_numbers!,
-          :remove_nonletters!,
-          :stem!,
-          :tag_pos!,
-          :remove_articles!,
-          :remove_indefinite_articles!,
-          :remove_definite_articles!,
-          :remove_prepositions!,
-          :remove_pronouns!,
-          :remove_stop_words!)
-    @eval begin
-        function ($f)(crps::Corpus)
-            for doc in crps
-                ($f)(doc)
-            end
-        end
-    end
-end
-
-function remove_words!{T <: String}(crps::Corpus, words::Vector{T})
+function remove_patterns!(crps::Corpus, rex::Regex)
     for doc in crps
-        remove_words!(doc, words)
+        remove_patterns!(doc, rex)
     end
 end
 
-##############################################################################
-#
-# Drop terms based on frequency
-#
-##############################################################################
+_build_regex(lang, flags::Uint32) = _build_regex(lang, flags, Set{String}(), Set{String}())
+_build_regex{T <: String}(lang, flags::Uint32, patterns::Set{T}, words::Set{T}) = _combine_regex(_build_regex_patterns(lang, flags, patterns, words))
 
-function sparse_terms(crps::Corpus, alpha::Real)
-    update_lexicon!(crps)
-    update_inverse_index!(crps)
-    t = crps.total_terms
-    res = Array(UTF8String, 0)
-    for term in keys(crps.lexicon)
-        f = length(crps.inverse_index[term]) / length(crps.documents)
-        if f <= alpha
-            push!(res, term)
-        end
+function _combine_regex{T <: String}(regex_parts::Set{T})
+    l = length(regex_parts)
+    (0 == l) && return r""
+    (1 == l) && return Regex(pop!(regex_parts), 0)
+
+    iob = IOBuffer()
+    write(iob, "($(pop!(regex_parts)))")
+    for part in regex_parts
+        write(iob, "|($part)")
     end
-    return res
+    Regex(takebuf_string(iob), 0)
 end
-sparse_terms(crps::Corpus) = sparse_terms(crps, 0.05)
 
-function frequent_terms(crps::Corpus, alpha::Real)
-    update_lexicon!(crps)
-    update_inverse_index!(crps)
-    t = crps.total_terms
-    res = Array(UTF8String, 0)
-    for term in keys(crps.lexicon)
-        f = length(crps.inverse_index[term]) / length(crps.documents)
-        if f >= alpha
-            push!(res, term)
-        end
+function _build_regex_patterns{T <: String}(lang, flags::Uint32, patterns::Set{T}, words::Set{T})
+    ((flags & strip_whitespace) > 0) && push!(patterns, "\\s+")
+    if (flags & strip_non_letters) > 0 
+        push!(patterns, "[^a-zA-Z\\s]")
+    else
+        ((flags & strip_punctuation) > 0) && push!(patterns, "[,;:.!?()]+")
+        ((flags & strip_numbers) > 0) && push!(patterns, "\\d+")
     end
-    return res
-end
-frequent_terms(crps::Corpus) = frequent_terms(crps, 0.05)
+    if (flags & strip_articles) > 0
+        union!(words, articles(lang))
+    else
+        ((flags & strip_indefinite_articles) > 0) && union!(words, indefinite_articles(lang))
+        ((flags & strip_definite_articles) > 0) && union!(words, definite_articles(lang))
+    end
+    ((flags & strip_prepositions) > 0) && union!(words, prepositions(lang))
+    ((flags & strip_pronouns) > 0) && union!(words, pronouns(lang))
+    ((flags & strip_stopwords) > 0) && union!(words, stopwords(lang))
 
-# Sparse terms occur in less than x percent of all documents
-function remove_sparse_terms!(crps::Corpus, alpha::Real)
-    remove_words!(crps, sparse_terms(crps, alpha))
-end
-function remove_sparse_terms!(crps::Corpus)
-    remove_sparse_terms!(crps, 0.05)
+    words_pattern = _build_words_pattern(collect(words))
+    !isempty(words_pattern) && push!(patterns, words_pattern)
+    patterns
 end
 
-# Frequent terms occur in more than x percent of all documents
-function remove_frequent_terms!(crps::Corpus, alpha::Real)
-    remove_words!(crps, frequent_terms(crps, alpha))
+function _build_words_pattern{T <: String}(words::Vector{T})
+    isempty(words) && return ""
+
+    iob = IOBuffer()
+    write(iob, "\\b(")
+    write(iob, words[1])
+    l = length(words)
+    for idx in 2:l
+        write(iob, '|')
+        write(iob, words[idx])
+    end
+    write(iob, ")\\b")
+    takebuf_string(iob)
 end
-function remove_frequent_terms!(crps::Corpus)
-    remove_frequent_terms!(crps, 0.95)
-end
+

--- a/src/tokenizer.jl
+++ b/src/tokenizer.jl
@@ -5,5 +5,5 @@
 ##############################################################################
 
 function tokenize{S <: Language}(::Type{S}, s::String)
-    return convert(Array{UTF8String, 1}, split(s, r"\s+"))
+    return convert(Array{UTF8String, 1}, matchall(r"[^\s]+", s))
 end

--- a/test/document.jl
+++ b/test/document.jl
@@ -14,10 +14,10 @@ text!(sd, sample_text1)
 @assert isequal(text(sd), sample_text1)
 
 @assert all(tokens(sd) .== ["This", "is", "a", "string"])
-@assert contains(keys(ngrams(sd, 1)), "This")
-@assert contains(keys(ngrams(sd, 1)), "is")
-@assert contains(keys(ngrams(sd, 1)), "a")
-@assert contains(keys(ngrams(sd, 1)), "string")
+@assert "This" in keys(ngrams(sd, 1))
+@assert "is" in keys(ngrams(sd, 1))
+@assert "a" in keys(ngrams(sd, 1))
+@assert "string" in keys(ngrams(sd, 1))
 
 @assert length(sd) == 16
 
@@ -45,7 +45,7 @@ my_ngrams["to"] = 1
 my_ngrams["be..."] = 1
 ngd = NGramDocument(my_ngrams)
 @assert isa(ngd, NGramDocument)
-@assert contains(keys(ngrams(ngd)), "To")
+@assert "To" in keys(ngrams(ngd))
 
 sd = StringDocument(hamlet_text)
 td = TokenDocument(hamlet_text)

--- a/test/preprocessing.jl
+++ b/test/preprocessing.jl
@@ -3,13 +3,11 @@ sample_text1_wo_punctuation = "This is 1 MESSED UP string"
 sample_text1_wo_punctuation_numbers = "This is  MESSED UP string"
 sample_text1_wo_punctuation_numbers_case = "this is  messed up string"
 
-sd = StringDocument(sample_text1)
-
-remove_punctuation!(sd)
-
-remove_numbers!(sd)
-
-remove_case!(sd)
+for str in [sample_text1, sample_text1_wo_punctuation, sample_text1_wo_punctuation_numbers, sample_text1_wo_punctuation_numbers_case]
+    sd = StringDocument(str)
+    prepare!(sd, strip_punctuation | strip_numbers | strip_case | strip_whitespace)
+    @assert isequal(strip(sd.text), "this is messed up string")
+end
 
 # Need to only remove words at word boundaries
 
@@ -18,31 +16,31 @@ remove_words!(doc, ["sample"])
 @assert isequal(doc.text, "this is   text")
 
 doc = Document("this is sample text")
-remove_articles!(doc)
+prepare!(doc, strip_articles)
 @assert isequal(doc.text, "this is sample text")
 
 doc = Document("this is sample text")
-remove_definite_articles!(doc)
+prepare!(doc, strip_definite_articles)
 @assert isequal(doc.text, "this is sample text")
 
 doc = Document("this is sample text")
-remove_indefinite_articles!(doc)
+prepare!(doc, strip_indefinite_articles)
 @assert isequal(doc.text, "this is sample text")
 
 doc = Document("this is sample text")
-remove_prepositions!(doc)
+prepare!(doc, strip_prepositions)
 @assert isequal(doc.text, "this is sample text")
 
 doc = Document("this is sample text")
-remove_pronouns!(doc)
+prepare!(doc, strip_pronouns)
 @assert isequal(doc.text, "this is sample text")
 
 doc = Document("this is sample text")
-remove_stop_words!(doc)
-@assert isequal(doc.text, "    sample text")
+prepare!(doc, strip_stopwords)
+@assert isequal(strip(doc.text), "sample text")
 
 doc = Document("this is sample text")
-remove_whitespace!(doc)
+prepare!(doc, strip_whitespace)
 @assert isequal(doc.text, "this is sample text")
 
 # stem!(sd)
@@ -50,4 +48,7 @@ remove_whitespace!(doc)
 
 # Do preprocessing on TokenDocument, NGramDocument, Corpus
 d = NGramDocument("this is sample text")
+@assert haskey(d.ngrams, "sample")
 remove_words!(d, ["sample"])
+@assert !haskey(d.ngrams, "sample")
+


### PR DESCRIPTION
Gives around 3x performance boost in a small test. Test involved creating simple inverted indices for text files (https://github.com/tanmaykm/julia_examples/blob/master/dinvidx/dinvidx2.jl)

Before:

```
julia> require("../dinvidx2.jl")

julia> @time create_index()
created 3 part indices
elapsed time: 30.271816734 seconds (3732874940 bytes allocated)

julia> @time create_index()
created 3 part indices
elapsed time: 27.022503601 seconds (3644058912 bytes allocated)
```

After:

```
julia> require("../dinvidx2.jl")

julia> @time create_index()
created 3 part indices
elapsed time: 11.244305093 seconds (849928456 bytes allocated)

julia> @time create_index()
created 3 part indices
elapsed time: 7.954268358 seconds (755496084 bytes allocated)
```
