### PR TITLE
Added HTML tag stripping

### DIFF
--- a/src/TextAnalysis.jl
+++ b/src/TextAnalysis.jl
@@ -33,6 +33,7 @@ module TextAnalysis
     export remove_definite_articles!, remove_indefinite_articles!
     export remove_prepositions, remove_pronouns, stem, tag_pos
     export remove_prepositions!, remove_pronouns!, stem!, tag_pos!
+    export remove_html_tags, remove_html_tags!
     export prepare!
     export frequent_terms, sparse_terms
     export remove_frequent_terms!, remove_sparse_terms!
@@ -45,7 +46,7 @@ module TextAnalysis
 
     export strip_patterns, strip_corrupt_utf8, strip_case, stem_words, tag_part_of_speech, strip_whitespace, strip_punctuation
     export strip_numbers, strip_non_letters, strip_indefinite_articles, strip_definite_articles, strip_articles
-    export strip_prepositions, strip_pronouns, strip_stopwords, strip_sparse_terms, strip_frequent_terms
+    export strip_prepositions, strip_pronouns, strip_stopwords, strip_sparse_terms, strip_frequent_terms, strip_html_tags
 
     include("tokenizer.jl")
     include("ngramizer.jl")

--- a/test/preprocessing.jl
+++ b/test/preprocessing.jl
@@ -52,3 +52,8 @@ d = NGramDocument("this is sample text")
 remove_words!(d, ["sample"])
 @assert !haskey(d.ngrams, "sample")
 
+d = StringDocument("<html><head><script language=\"javascript\"> x = 20; </script></head><body><h1>Hello</h1><a href=\"world\">world</a>")
+remove_html_tags!(d)
+@assert "Hello world" == strip(d.text)
+
+


### PR DESCRIPTION
This adds:
- a new flag `strip_html_tags` for `preprocess!` to remove HTML tags from a StringDocument or Corpus.
- methods `remove_html_tags` and `remove_html_tags!` to be called separately
- a test case for the above.
