### PR TITLE
Removed unintended dependency on Stemmers.jl. Fixed warning in build.jl.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -24,7 +24,7 @@ end
     cd(srchome)
     run(`tar xvzf $dnldfile`)
     cd(srcdir)
-    run(`cat $patchpath` | `patch`)
+    run(`cat $patchpath` |> `patch`)
     for mkcmd in (:gnumake, :gmake, :make)
         try
             if success(`$mkcmd`)

--- a/src/stemmer.jl
+++ b/src/stemmer.jl
@@ -1,5 +1,5 @@
 
-const _libsb = joinpath(Pkg.dir(),"Stemmers","deps","usr","lib", "libstemmer."*BinDeps.shlib_ext)
+const _libsb = joinpath(Pkg.dir(),"TextAnalysis","deps","usr","lib", "libstemmer."*BinDeps.shlib_ext)
 #const _libsb = "libstemmer"
 
 ##


### PR DESCRIPTION
Fixed an oversight in last commit because of which `TextAnalysis.jl` was referring to `Stemmers.jl` even after merging the two.

Also fixed a deprecation warning in `build.jl` for `|>`.
