### PR TITLE
Add some symbols to punctuation in strip_punctuation

### DIFF
--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -362,7 +362,7 @@ function _build_regex_patterns{T <: String}(lang, flags::Uint32, patterns::Set{T
     if (flags & strip_non_letters) > 0 
         push!(patterns, "[^a-zA-Z\\s]")
     else
-        ((flags & strip_punctuation) > 0) && push!(patterns, "[,;:.!?()]+")
+        ((flags & strip_punctuation) > 0) && push!(patterns, "[\"',;:.!?()]+")
         ((flags & strip_numbers) > 0) && push!(patterns, "\\d+")
     end
     if (flags & strip_articles) > 0


### PR DESCRIPTION
Hi,

Since `"` and `'` are considered punctuation in English, I thought it would be a good idea to add this characters in the function `strip_punctuation!` in the `preprocessing` module. I don't know if there is a reason for not including them in the regex, but I needed them in a project of mine, so here is a patch if you think it could be useful for others too.

Bests,
Remusao
