### PR TITLE
made Corpus struct parametric as well as its constructor that takes docs vector

### DIFF
--- a/src/corpus.jl
+++ b/src/corpus.jl
@@ -4,17 +4,15 @@
 #
 ##############################################################################
 
-# TODO: Make this a parametric type?
-
-type Corpus
-    documents::Vector{GenericDocument}
+mutable struct Corpus{T <: AbstractDocument}
+    documents::Vector{T}
     total_terms::Int
     lexicon::Dict{String, Int}
     inverse_index::Dict{String, Vector{Int}}
     h::TextHashFunction
 end
 
-function Corpus(docs::Vector{GenericDocument})
+function Corpus(docs::Vector{T}) where {T <: AbstractDocument}
     Corpus(
         docs,
         0,

--- a/test/corpus.jl
+++ b/test/corpus.jl
@@ -13,6 +13,7 @@ module TestCorpus
     ngd = NGramDocument(sample_text1)
 
     crps = Corpus(Any[sd, fd, td, ngd])
+    crps2 = Corpus([ngd, ngd])
 
     documents(crps)
 


### PR DESCRIPTION
This constructor previously didn't work in julia v0.6