### PR TITLE
Use instance instead of type in language setter

### DIFF
--- a/docs/src/documents.md
+++ b/docs/src/documents.md
@@ -91,7 +91,7 @@ In addition to methods for manipulating the representation of the text of a
 document, every document object also stores basic metadata about itself,
 including the following pieces of information:
 
-* `language()`: What language is the document in? Defaults to `EnglishLanguage`, a Language type defined by the Languages package.
+* `language()`: What language is the document in? Defaults to `Languages.English()`, a Language instance defined by the Languages package.
 * `name()`: What is the name of the document? Defaults to `"Unnamed Document"`.
 * `author()`: Who wrote the document? Defaults to `"Unknown Author"`.
 * `timestamp()`: When was the document written? Defaults to `"Unknown Time"`.
@@ -107,7 +107,7 @@ in practice:
 If you need reset these fields, you can use the mutating versions of the same
 functions:
 
-    language!(sd, Languages.SpanishLanguage)
+    language!(sd, Languages.SpanishLanguage())
     name!(sd, "El Cid")
     author!(sd, "Desconocido")
     timestamp!(sd, "Desconocido")

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -15,7 +15,7 @@ function name!(d::AbstractDocument, nv::AbstractString)
     d.metadata.name = nv
 end
 
-function language!{T <: Language}(d::AbstractDocument, nv::Type{T})
+function language!{T <: Language}(d::AbstractDocument, nv::T)
     d.metadata.language = nv
 end
 

--- a/test/metadata.jl
+++ b/test/metadata.jl
@@ -13,4 +13,7 @@ module TestMetadata
     @assert isequal(language(sd), Languages.English())
     @assert isequal(author(sd), "Unknown Author")
     @assert isequal(timestamp(sd), "Unknown Time")
+
+    language!(sd, Languages.German())
+    @assert isequal(language(sd), Languages.German())
 end


### PR DESCRIPTION
The latest changes to the Languages API require instances instead of types. If we use the type as in the current version further preprocessing fails. This should fix the language setter. A simple test case is provided. Documentation is updated.