### PR TITLE
bug fixes for DTM constructor and for remove_patterns

### DIFF
--- a/src/dtm.jl
+++ b/src/dtm.jl
@@ -30,10 +30,13 @@ function DocumentTermMatrix(crps::Corpus, lex)
     terms = sort(collect(keys(lex)))
     column_indices = columnindices(terms)
 
+    m = length(crps)
+    n = length(terms)
+
     rows = Array{Int}(0)
     columns = Array{Int}(0)
     values = Array{Int}(0)
-    for i in 1:length(crps)
+    for i in 1:m
         doc = crps.documents[i]
         ngs = ngrams(doc)
         for ngram in keys(ngs)
@@ -47,9 +50,9 @@ function DocumentTermMatrix(crps::Corpus, lex)
         end
     end
     if length(rows) > 0
-        dtm = sparse(rows, columns, values)
+        dtm = sparse(rows, columns, values, m, n)
     else
-        dtm = spzeros(Int, length(crps), 0)
+        dtm = spzeros(Int, m, n)
     end
     DocumentTermMatrix(dtm, terms, column_indices)
 end
@@ -99,7 +102,7 @@ function dtm_entries(d::AbstractDocument, lex::Dict{String, Int})
     values = Array{Int}(0)
     terms = sort(collect(keys(lex)))
     column_indices = columnindices(terms)
-    
+
     for ngram in keys(ngs)
         if haskey(column_indices, ngram)
             push!(indices, column_indices[ngram])

--- a/src/dtm.jl
+++ b/src/dtm.jl
@@ -26,8 +26,7 @@ function columnindices(terms::Vector{String})
     column_indices
 end
 
-function DocumentTermMatrix(crps::Corpus, lex)
-    terms = sort(collect(keys(lex)))
+function DocumentTermMatrix(crps::Corpus, terms::Vector{String})
     column_indices = columnindices(terms)
 
     m = length(crps)
@@ -57,6 +56,8 @@ function DocumentTermMatrix(crps::Corpus, lex)
     DocumentTermMatrix(dtm, terms, column_indices)
 end
 DocumentTermMatrix(crps::Corpus) = DocumentTermMatrix(crps, lexicon(crps))
+
+DocumentTermMatrix(crps::Corpus, lex::Associative) = DocumentTermMatrix(crps, sort(collect(keys(lex))))
 
 DocumentTermMatrix(dtm::SparseMatrixCSC{Int, Int},terms::Vector{String}) = DocumentTermMatrix(dtm, terms, columnindices(terms))
 

--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -258,7 +258,7 @@ function remove_patterns(s::AbstractString, rex::Regex)
             Base.write_sub(iob, v, ibegin, len)
             write(iob, ' ')
         end
-        ibegin = m.endof+m.offset+1
+        ibegin = nextind(s, m.endof+m.offset)
     end
     len = length(v) - ibegin + 1
     (len > 0) && Base.write_sub(iob, v, ibegin, len)
@@ -276,7 +276,7 @@ function remove_patterns{T <: String}(s::SubString{T}, rex::Regex)
             Base.write_sub(iob, data, ibegin+ioffset, len)
             write(iob, ' ')
         end
-        ibegin = m.endof+m.offset+1
+        ibegin = nextind(s, m.endof+m.offset)
     end
     len = s.endof - ibegin + 1
     (len > 0) && Base.write_sub(iob, data, ibegin+ioffset, len)

--- a/test/dtm.jl
+++ b/test/dtm.jl
@@ -34,7 +34,14 @@ module TestDTM
     tdm(crps)
     hash_tdm(crps)
 
-    # construct a DocumentTermMatrix from a dtm and a custom lexicon
+    # construct a DocumentTermMatrix from a crps and a custom terms vector
+    terms = ["And", "notincrps"]
+    m = DocumentTermMatrix(crps,terms)
+    @test size(dtm(m),1) == length(terms)
+    @test terms == m.terms
+    @test size(dtm(m),2) == length(crps)
+
+    # construct a DocumentTermMatrix from a crps and a custom lexicon
     lex = Dict("And"=>1, "notincrps"=>4)
     m = DocumentTermMatrix(crps,lex)
     @test size(dtm(m),1) == length(keys(lex))

--- a/test/dtm.jl
+++ b/test/dtm.jl
@@ -34,6 +34,13 @@ module TestDTM
     tdm(crps)
     hash_tdm(crps)
 
+    # construct a DocumentTermMatrix from a dtm and a custom lexicon
+    lex = Dict("And"=>1, "notincrps"=>4)
+    m = DocumentTermMatrix(crps,lex)
+    @test size(dtm(m),1) == length(keys(lex))
+    @test size(dtm(m),1) == length(m.terms)
+    @test size(dtm(m),2) == length(crps)
+
     # construct a DocumentTermMatrix from a dtm and terms vector
     terms = m.terms
     m2 = DocumentTermMatrix(dtm1,terms)

--- a/test/preprocessing.jl
+++ b/test/preprocessing.jl
@@ -24,7 +24,6 @@ module TestPreprocessing
             sd,
             strip_punctuation | strip_numbers | strip_case | strip_whitespace | strip_non_letters
         )
-        info("sd=$sd")
         @assert isequal(strip(sd.text), "this is messed string")
     end
 

--- a/test/preprocessing.jl
+++ b/test/preprocessing.jl
@@ -3,16 +3,18 @@ module TestPreprocessing
     using Languages
     using TextAnalysis
 
-    sample_text1 = "This is 1 MESSED UP string!"
-    sample_text1_wo_punctuation = "This is 1 MESSED UP string"
-    sample_text1_wo_punctuation_numbers = "This is  MESSED UP string"
-    sample_text1_wo_punctuation_numbers_case = "this is  messed up string"
+    sample_text1 = "This is 1 MESSED υπ string!"
+    sample_text1_wo_punctuation = "This is 1 MESSED υπ string"
+    sample_text1_wo_punctuation_numbers = "This is  MESSED υπ string"
+    sample_text1_wo_punctuation_numbers_case = "this is  messed υπ string"
+    sample_text1_wo_punctuation_numbers_case_az = "this is  messed  string"
 
     sample_texts = [
         sample_text1,
         sample_text1_wo_punctuation,
         sample_text1_wo_punctuation_numbers,
         sample_text1_wo_punctuation_numbers_case,
+        sample_text1_wo_punctuation_numbers_case_az
     ]
 
     # This idiom is _really_ ugly since "OR" means "AND" here.
@@ -20,9 +22,10 @@ module TestPreprocessing
         sd = StringDocument(str)
         prepare!(
             sd,
-            strip_punctuation | strip_numbers | strip_case | strip_whitespace
+            strip_punctuation | strip_numbers | strip_case | strip_whitespace | strip_non_letters
         )
-        @assert isequal(strip(sd.text), "this is messed up string")
+        info("sd=$sd")
+        @assert isequal(strip(sd.text), "this is messed string")
     end
 
     # Need to only remove words at word boundaries


### PR DESCRIPTION
Note that the remove_patterns fix will have to be revisited to support julia 1.0 because SubString no longer has the endof field, but does have ncodeunits.

I added some utf8 chars to the test string which would fail before this fix.