### PR TITLE
Fix language in stemmer type specification

### DIFF
--- a/src/stemmer.jl
+++ b/src/stemmer.jl
@@ -87,7 +87,7 @@ function stem(stemmer::Stemmer, words::Array)
 end
 
 function stemmer_for_document(d::AbstractDocument)
-    Stemmer(lowercase(name(language(d))))
+    Stemmer(lowercase(Languages.english_name(language(d))))
 end
 
 function stem!(d::AbstractDocument)


### PR DESCRIPTION
The language passed to the stemmer is inferred using `name(language(d))` where `d` is an `AbstractDocument`. This is a language name in that language, e.g., `"русский"` for Russian. Snowball stemmer, however, requires an English name or an ISO code:
> The algorithm may be selected using the english name of the
> language, or using the 2 or 3 letter ISO 639 language codes.

This fix infers English language name. 

(Tested only on Russian).