### PR TITLE
Fix language specificaion in stemmer type

### DIFF
--- a/src/stemmer.jl
+++ b/src/stemmer.jl
@@ -87,7 +87,7 @@ function stem(stemmer::Stemmer, words::Array)
 end
 
 function stemmer_for_document(d::AbstractDocument)
-    Stemmer(lowercase(name(language(d))))
+    Stemmer(lowercase(Languages.english_name(language(d))))
 end
 
 function stem!(d::AbstractDocument)


### PR DESCRIPTION
Currently the language for the stemmer is inferred using `name(language(d))` where `d` is an `::AsbtractDocument`. This produces the name of the language in that language (e.g., `"русский"` for Russian). Snowball stemmer, however, [requires](https://github.com/snowballstem/snowball/blob/master/doc/libstemmer_c_README) it be in English or as an ISO code:

> [...] The algorithm may be selected using the english name of the
> language, or using the 2 or 3 letter ISO 639 language codes. [...]

This PR fixes it by using `english_name` instead of `name`, thus producing, e.g., `"russian"` instead of `"русский"`.

(Tested only on Russian)