### PR TITLE
changed remove_patterns

### DIFF
--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -254,11 +254,14 @@ function remove_patterns(s::AbstractString, rex::Regex)
     v=codeunits(s)
     for m in eachmatch(rex, s)
         len = m.match.offset-ibegin+1
+	next = nextind(s, lastindex(m.match)+m.match.offset)
         if len > 0
             Base.write_sub(iob, v, ibegin, len)
-            write(iob, ' ')
+	    if  next != length(s)+1
+            	write(iob, ' ')
+	    end
         end
-        ibegin = nextind(s, lastindex(m.match)+m.match.offset)
+        ibegin = next
     end
     len = length(v) - ibegin + 1
     (len > 0) && Base.write_sub(iob, v, ibegin, len)
@@ -272,16 +275,20 @@ function remove_patterns(s::SubString{T}, rex::Regex) where T <: String
     ibegin = 1
     for m in eachmatch(rex, s)
         len = m.match.offset-ibegin+1
+	next = nextind(s, lastindex(m.match)+m.match.offset)
         if len > 0
             Base.write_sub(iob, data, ibegin+ioffset, len)
-            write(iob, ' ')
+            if  next != length(s)+1
+            	write(iob, ' ')
+	    end
         end
-        ibegin = nextind(s, lastindex(m.match)+m.match.offset)
+        ibegin = next
     end
     len = lastindex(s) - ibegin + 1
     (len > 0) && Base.write_sub(iob, data, ibegin+ioffset, len)
     String(take!(iob))
 end
+
 
 remove_patterns!(d::FileDocument, rex::Regex) = error("FileDocument cannot be modified")
 

--- a/test/preprocessing.jl
+++ b/test/preprocessing.jl
@@ -93,7 +93,7 @@
 
     #Tests strip_punctuation regex conditions
     str = Document("These punctuations should be removed [-.,:;,!?'\"[](){}|\`#\$%@^&*_+<>")
-    answer = Document("These punctuations should be removed  ")
+    answer = Document("These punctuations should be removed ")
     prepare!(str, strip_punctuation)
     @test isequal(str.text, answer.text)
 
@@ -101,4 +101,9 @@
     answer = Document("Intel tm  Core i5 3300k  is a geat CPU  ")   #tests old implementation   
     prepare!(str, strip_punctuation)
     @test isequal(str.text, answer.text)
+
+    #Tests no whitespace at end or begining
+    doc = Document("   this is sample text   ")
+    prepare!(doc, strip_whitespace)
+    @test isequal(doc.text, "this is sample text")
 end


### PR DESCRIPTION
In issue #100 it was asked to strip whitespaces and the result should not contain whitespaces at beginning or end of string. In the already laid out method, every `regex` match was replaced with a `' '` except at the matches occurring at the beginning of the string.
Following the used methodology, this patch does the same for matches at the end
i.e does not replaces the last match with `' '`  

Closes: https://github.com/JuliaText/TextAnalysis.jl/issues/100