### PR TITLE
Add extended example doc

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,7 +12,8 @@ makedocs(
        "Documents" => "documents.md",
        "Corpus" => "corpus.md",
        "Features" => "features.md",
-       "Semantic Analysis" => "semantic.md"
+       "Semantic Analysis" => "semantic.md",
+       "Extended Example" => "example.md"
    ],
    assets = ["assets/custom.css", "assets/custom.js"]
 )

--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -1,0 +1,30 @@
+# Extended Usage Example
+
+To show you how text analysis might work in practice, we're going to work with
+a text corpus composed of political speeches from American presidents given
+as part of the State of the Union Address tradition.
+
+    using TextAnalysis, MultivariateStats, Clustering
+
+    crps = DirectoryCorpus("sotu")
+
+    standardize!(crps, StringDocument)
+
+    crps = Corpus(crps[1:30])
+
+    remove_case!(crps)
+    remove_punctuation!(crps)
+
+    update_lexicon!(crps)
+    update_inverse_index!(crps)
+
+    crps["freedom"]
+
+    m = DocumentTermMatrix(crps)
+
+    D = dtm(m, :dense)
+
+    T = tf_idf(D)
+
+    cl = kmeans(T, 5)
+


### PR DESCRIPTION
Adding Extended example doc. which was dropped while reorganising docs.

Closes: https://github.com/JuliaText/TextAnalysis.jl/issues/72