### PR TITLE
add handle_unknown function to sentiment.jl

### DIFF
--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -76,3 +76,15 @@ You can work around this by performing TF-IDF on a DocumentTermMatrix:
 As you can see, TF-IDF has the effect of inserting 0's into the columns of
 words that occur in all documents. This is a useful way to avoid having to
 remove those words during preprocessing.
+
+## Sentiment Analyzer
+
+It can be used to find the sentiment score (between 0 and 1) of a word, sentence or a Document.
+A trained model (using Flux) on IMDB word corpus with weights saved are used to calculate the sentiments.
+
+    model = SentimentAnalyzer(doc)
+    model = SentimentAnalyzer(doc, handle_unknown)
+
+*  doc              = Input Document for calculating document (AbstractDocument type)
+*  handle_unknown   = A function for handling unknown words. Should return an array (default (x)->[])
+ 

--- a/src/sentiment.jl
+++ b/src/sentiment.jl
@@ -35,7 +35,7 @@ function flatten(x)
     return reshape(x, (l, 1))
 end
 
-function get_sentiment(ip::Array{T, 1}, weight, rwi, handle_unk) where T <: AbstractString
+function get_sentiment(ip::Array{T, 1}, weight, rwi, handle_unknown) where T <: AbstractString
     model = (x,) -> begin
     a_1 = embedding(weight[:embedding_1]["embedding_1"]["embeddings:0"], x)
     a_2 = flatten(a_1)
@@ -48,7 +48,7 @@ function get_sentiment(ip::Array{T, 1}, weight, rwi, handle_unk) where T <: Abst
 	if ele in keys(rwi)
             push!(res, rwi[ele])
 	else
-	    vcat(res, handle_unk(ele))
+	    vcat(res, handle_unknown(ele))
 	end
     end
     return model(pad_sequences(res))[1]
@@ -78,10 +78,22 @@ function Base.show(io::IO, s::SentimentAnalyzer)
 end
 
 
-function(m::SentimentModel)(text::Array{T, 1}, handle_unk) where T <: AbstractString
-    return get_sentiment(text, m.weight, m.words, handle_unk)
+function(m::SentimentModel)(text::Array{T, 1}, handle_unknown) where T <: AbstractString
+    return get_sentiment(text, m.weight, m.words, handle_unknown)
 end
 
-function(m::SentimentAnalyzer)(d::AbstractDocument, handle_unk::Function= (x)->[])
-    m.model(tokens(d), handle_unk)
+
+"""
+ ```
+ model = SentimentAnalyzer(doc)
+ model = SentimentAnalyzer(doc, handle_unknown)
+ ```
+ Return sentiment of the input doc in range 0 to 1, 0 being least sentiment score and 1 being
+ the highest:
+  -  doc              = Input Document for calculating document (AbstractDocument type)
+  -  handle_unknown   = A function for handling unknown words. Should return an array (default (x)->[])
+ """
+
+function(m::SentimentAnalyzer)(d::AbstractDocument, handle_unknown::Function = (x)->[])
+    m.model(tokens(d), handle_unknown)
 end

--- a/src/sentiment.jl
+++ b/src/sentiment.jl
@@ -35,7 +35,7 @@ function flatten(x)
     return reshape(x, (l, 1))
 end
 
-function get_sentiment(ip::Array{T, 1}, weight, rwi, handle_unknown) where T <: AbstractString
+function get_sentiment(handle_unknown, ip::Array{T, 1}, weight, rwi) where T <: AbstractString
     model = (x,) -> begin
     a_1 = embedding(weight[:embedding_1]["embedding_1"]["embeddings:0"], x)
     a_2 = flatten(a_1)
@@ -45,7 +45,7 @@ function get_sentiment(ip::Array{T, 1}, weight, rwi, handle_unknown) where T <: 
     end
     res = Array{Int, 1}()
     for ele in ip
-	if ele in keys(rwi) && rwi[ele] <= 5000    # there are only 5000 unique embeddings
+	if ele in keys(rwi) && rwi[ele] <= size(weight[:embedding_1]["embedding_1"]["embeddings:0"])[2]   # there are only 5000 unique embeddings
             push!(res, rwi[ele])
 	else
 	    vcat(res, handle_unknown(ele))
@@ -78,8 +78,8 @@ function Base.show(io::IO, s::SentimentAnalyzer)
 end
 
 
-function(m::SentimentModel)(text::Array{T, 1}, handle_unknown) where T <: AbstractString
-    return get_sentiment(text, m.weight, m.words, handle_unknown)
+function(m::SentimentModel)(handle_unknown, text::Array{T, 1}) where T <: AbstractString
+    return get_sentiment(handle_unknown, text, m.weight, m.words)
 end
 
 
@@ -91,9 +91,9 @@ end
  Return sentiment of the input doc in range 0 to 1, 0 being least sentiment score and 1 being
  the highest:
   -  doc              = Input Document for calculating document (AbstractDocument type)
-  -  handle_unknown   = A function for handling unknown words. Should return an array (default (x)->[])
+  -  handle_unknown   = A function for handling unknown words. Should return an array (default x->tuple())
  """
 
-function(m::SentimentAnalyzer)(d::AbstractDocument, handle_unknown::Function = (x)->[])
-    m.model(tokens(d), handle_unknown)
+function(m::SentimentAnalyzer)(d::AbstractDocument, handle_unknown = x->tuple())
+    m.model(handle_unknown, tokens(d))
 end

--- a/src/sentiment.jl
+++ b/src/sentiment.jl
@@ -48,7 +48,12 @@ function get_sentiment(handle_unknown, ip::Array{T, 1}, weight, rwi) where T <: 
 	if ele in keys(rwi) && rwi[ele] <= size(weight[:embedding_1]["embedding_1"]["embeddings:0"])[2]   # there are only 5000 unique embeddings
             push!(res, rwi[ele])
 	else
-	    vcat(res, handle_unknown(ele))
+	    for words in handle_unknown(ele) 
+		if words in keys(rwi) && rwi[words] <= size(weight[:embedding_1]["embedding_1"]["embeddings:0"])[2]
+		    push!(res, rwi[words])
+		end
+	    end	
+		
 	end
     end
     return model(pad_sequences(res))[1]

--- a/src/sentiment.jl
+++ b/src/sentiment.jl
@@ -45,7 +45,7 @@ function get_sentiment(ip::Array{T, 1}, weight, rwi, handle_unknown) where T <: 
     end
     res = Array{Int, 1}()
     for ele in ip
-	if ele in keys(rwi)
+	if ele in keys(rwi) && rwi[ele] <= 5000    # there are only 5000 unique embeddings
             push!(res, rwi[ele])
 	else
 	    vcat(res, handle_unknown(ele))

--- a/test/sentiment.jl
+++ b/test/sentiment.jl
@@ -23,4 +23,10 @@
     d = Document("a Horrible thing that Everyone Hates")
    
     @test m(d, (x) -> [lowercase(x)]) < 0.5
+
+    # Make it throw an error when unknown word encountered
+    d = Document("some sense and some Hectic")
+   
+    @test_throws ErrorException m(d, (x) -> error("OOV word $x encountered"))
+
 end

--- a/test/sentiment.jl
+++ b/test/sentiment.jl
@@ -9,7 +9,15 @@
 
     @test m(d) < 0.5
 
-   d = StringDocument("some sense and some nonSense")
+    # testing default behaviour of handle_unknown
+    d = StringDocument("some sense and some nonSense")
 
-   @test m(d) < 0.5
+    @test m(d) < 0.5
+
+    # testing behaviour of words which are present in dictionary but do not have embedding assigned
+    d = StringDocument("some sense and some duh")
+
+    @test m(d) < 0.5
+
+
 end

--- a/test/sentiment.jl
+++ b/test/sentiment.jl
@@ -8,4 +8,8 @@
     d = StringDocument("a horrible thing that everyone hates")
 
     @test m(d) < 0.5
+
+   d = StringDocument("some sense and some nonSense")
+
+   @test m(d) < 0.5
 end

--- a/test/sentiment.jl
+++ b/test/sentiment.jl
@@ -19,5 +19,8 @@
 
     @test m(d) < 0.5
 
-
+    # testing user given handle_unknown function
+    d = Document("a Horrible thing that Everyone Hates")
+   
+    @test m(d, (x) -> [lowercase(x)]) < 0.5
 end


### PR DESCRIPTION
Added a default function to handle unknown words while using `SentimentAnalyser`.
Default function: Skips the word

Closes: https://github.com/JuliaText/TextAnalysis.jl/issues/83
Closes: https://github.com/JuliaText/TextAnalysis.jl/issues/122