### PR TITLE
Fix indentation in Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
 language: julia
 os:
-    - linux
+  - linux
 julia:
-    - 0.7
-    - 1.0
+  - 0.7
+  - 1.0
 notifications:
-    email: false
+  email: false
 jobs:
-    include:
-        - stage: "Documentation"
-          julia: 1.0
-          os: linux
-          script:
-              - julia --project=docs/ -e 'using Pkg;
-                                          Pkg.develop(PackageSpec(path=pwd()));
-                                          Pkg.instantiate();
-                                          Pkg.build();'
-              - julia --project=docs/ docs/make.jl
-        after_success: skip
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg;
+                                    Pkg.develop(PackageSpec(path=pwd()));
+                                    Pkg.instantiate();
+                                    Pkg.build();'
+        - julia --project=docs/ docs/make.jl
+      after_success: skip
 after_success:
-    - julia -e 'cd(Pkg.dir("TextAnalysis")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';
+  - julia -e 'cd(Pkg.dir("TextAnalysis")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())';


### PR DESCRIPTION
It looks like I messed up the indentation in PR #127. [Travis could not parse the `.travis.yml`](https://travis-ci.org/JuliaText/TextAnalysis.jl/requests). This PR should fix this.