### PR TITLE
Remove HTML style tags in preprocessing

### DIFF
--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -124,10 +124,12 @@ end
 #
 ##############################################################################
 const script_tags = Regex("<script\\b[^>]*>([\\s\\S]*?)</script>")
+const style_tags = Regex("<style\\b[^>]*>([\\s\\S]*?)</style>")
 const html_tags = Regex("<[^>]*>")
 
 function remove_html_tags(s::AbstractString)
     s = remove_patterns(s, script_tags)
+    s = remove_patterns(s, style_tags)
     remove_patterns(s, html_tags)
 end
 

--- a/test/preprocessing.jl
+++ b/test/preprocessing.jl
@@ -82,6 +82,26 @@
     remove_html_tags!(d)
     @test "Hello world" == strip(d.text)
 
+    style_html_doc = StringDocument(
+      """
+        <html>
+            <head>
+                <script language=\"javascript\"> x = 20; </script>
+            </head>
+            <body>
+                <style>
+                  .fake-style {
+                    color: #00ff00;
+                  }
+                </style>
+                <h1>Hello</h1><a href=\"world\">world</a>
+            </body>
+        </html>
+      """
+     )
+    remove_html_tags!(style_html_doc)
+    @test "Hello world" == strip(style_html_doc.text)
+
     #Test #62
     remove_corrupt_utf8("abc") == "abc"
     remove_corrupt_utf8(String([0x43, 0xf0])) == "C "


### PR DESCRIPTION
As we remove HTML tags in preprocessing, we should also be cognizant of any rogue `<style>` tags and remove those as needed as well.

Let me know if there is anything else I can add or change to get this merged in. Thank you for this wonderful library!