### PR TITLE
PR: To address performance issues with stopword removal

### DIFF
--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -300,25 +300,6 @@ function prepare!(d::AbstractDocument, flags::UInt32; skip_patterns = Set{Abstra
     nothing
 end
 
-#function remove_patterns(s::AbstractString, rex::Regex)
-#    iob = IOBuffer()
-#    ibegin = 1
-#    v=codeunits(s)
-#    for m in eachmatch(rex, s)
-#        len = m.match.offset-ibegin+1
-#       next = nextind(s, lastindex(m.match)+m.match.offset)
-#        if len > 0
-#            Base.write_sub(iob, v, ibegin, len)
-#           if  next != length(s)+1
-#               write(iob, ' ')
-#           end
-#        end
-#        ibegin = next
-#    end
-#    len = length(v) - ibegin + 1
-#    (len > 0) && Base.write_sub(iob, v, ibegin, len)
-#    String(take!(iob))
-#end
 
 """
     remove_whitespace(s::AbstractString)

--- a/test/preprocessing.jl
+++ b/test/preprocessing.jl
@@ -28,7 +28,7 @@
     # Need to only remove words at word boundaries
     doc = Document("this is sample text")
     remove_words!(doc, ["sample"])
-    @test isequal(doc.text, "this is   text")
+    @test isequal(doc.text, "this is  text")
 
     doc = Document("this is sample text")
     prepare!(doc, strip_articles)
@@ -74,7 +74,7 @@
                 <script language=\"javascript\"> x = 20; </script>
             </head>
             <body>
-                <h1>Hello</h1><a href=\"world\">world</a>
+                <h1>Hello</h1><a href=\"world\"> world</a>
             </body>
         </html>
         """
@@ -94,7 +94,7 @@
                     color: #00ff00;
                   }
                 </style>
-                <h1>Hello</h1><a href=\"world\">world</a>
+                <h1>Hello</h1><a href=\"world\"> world</a>
             </body>
         </html>
       """
@@ -118,7 +118,7 @@
     @test isequal(str.text, answer.text)
 
     str = Document("Intel(tm) Core i5-3300k, is a geat CPU! ")
-    answer = Document("Intel tm  Core i5 3300k  is a geat CPU  ")   #tests old implementation   
+    answer = Document("Inteltm Core i53300k is a geat CPU ")   #tests old implementation   
     prepare!(str, strip_punctuation)
     @test isequal(str.text, answer.text)
 


### PR DESCRIPTION
PR to address performance regression stated in #140. This brings the time down from 940s to 0.27s for my test dataset (~3.4MB)

primary change is replacement of  method `remove_patterns` which forced modification of `strip_whitespace` implementation of `prepare!` method
 
```julia
function remove_patterns(s::AbstractString, rex::Regex) 
  return replace(s, rex => "")
end
```

I have also modified test cases to make them consistent; where stripping punctuation or stripping a pattern replaces the matched pattern with `0` length string i.e. deletes the matched pattern. 

This required special handling for whitespace removal, where one or more than single space is replaced with a `blank_space` of length 1. And all leading and trailing spaces are stripped. 

I don't think there is a right way for certain pre-processing tasks. For example: with `strip_punctuation` what is the correct way to handle the following strings when removing punctuations.

- `don't mind!` => `don t mind ` or `dont mind` 
- `Intel(tm) Core i5-3300k` => `Intel tm  Core i5 3300k` or `Inteltm Core i53300k`
