### PR TITLE
Add characters to list of punctuations

### DIFF
--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -418,7 +418,7 @@ function _build_regex_patterns(lang, flags::UInt32, patterns::Set{T}, words::Set
     if (flags & strip_non_letters) > 0
         push!(patterns, "[^a-zA-Z\\s]")
     else
-        ((flags & strip_punctuation) > 0) && push!(patterns, "[-.,:;,!?'\"\\[\\]\\(\\)\\{\\}|\\`#\$%@^&*_+<>]+")
+        ((flags & strip_punctuation) > 0) && push!(patterns, "[-.,:;,!?'\"\\[\\]\\(\\)\\{\\}|\\`#\$%@^&*_+<>“”—’‘/]+")
         ((flags & strip_numbers) > 0) && push!(patterns, "\\d+")
     end
     if (flags & strip_articles) > 0


### PR DESCRIPTION
While analyzing text from Gutenberg project I realized that the list of punctuations does not include character `“”—’‘/`. I have added these to the list for completeness. 
