### PR TITLE
Add offline Documentation (Docstrings) to the codebase

### DIFF
--- a/docs/src/documents.md
+++ b/docs/src/documents.md
@@ -266,6 +266,7 @@ julia> remove_words!(sd, ["lear"])
 julia> sd
 StringDocument{String}(" is mad", TextAnalysis.DocumentMetadata(Languages.English(), "Untitled Document", "Unknown Author", "Unknown Time"))
 ```
+
 At other times, you'll want to remove whole classes of words. To make this
 easier, we can use several classes of basic words defined by the Languages.jl
 package:
@@ -294,6 +295,7 @@ These special classes can all be removed using specially-named parameters:
 These functions use words lists, so they are capable of working for many
 different languages without change, also these operations can be combined
 together for improved performance:
+
 * `prepare!(sd, strip_articles| strip_numbers| strip_html_tags)`
 
 In addition to removing words, it is also common to take words that are

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -126,6 +126,37 @@ julia> hash_dtv(crps[1])
  0  0  0  0  0  0  0  0  0  0  0  0  0  …  0  0  0  0  0  0  0  0  0  0  0  0
 ```
 
+## TF (Term Frequency)
+
+Often we need to find out the proportion of a document is contributed
+by each term. This can be done by finding the term frequency function
+
+    tf(dtm)
+
+The paramter, `dtm` can be of the types - `DocumentTermMatrix` , `SparseMatrixCSC` or `Matrix`
+
+```julia
+julia> crps = Corpus([StringDocument("To be or not to be"),
+              StringDocument("To become or not to become")])
+
+julia> update_lexicon!(crps)
+
+julia> m = DocumentTermMatrix(crps)
+
+julia> tf(m)
+2×6 SparseArrays.SparseMatrixCSC{Float64,Int64} with 10 stored entries:
+  [1, 1]  =  0.166667
+  [2, 1]  =  0.166667
+  [1, 2]  =  0.333333
+  [2, 3]  =  0.333333
+  [1, 4]  =  0.166667
+  [2, 4]  =  0.166667
+  [1, 5]  =  0.166667
+  [2, 5]  =  0.166667
+  [1, 6]  =  0.166667
+  [2, 6]  =  0.166667
+```
+
 ## TF-IDF (Term Frequency - Inverse Document Frequency)
 
 In many cases, raw word counts are not appropriate for use because:
@@ -135,8 +166,38 @@ In many cases, raw word counts are not appropriate for use because:
 
 You can work around this by performing TF-IDF on a DocumentTermMatrix:
 
-    m = DocumentTermMatrix(crps)
-    tf_idf(m)
+```julia
+julia> crps = Corpus([StringDocument("To be or not to be"),
+              StringDocument("To become or not to become")])
+
+julia> update_lexicon!(crps)
+
+julia> m = DocumentTermMatrix(crps)
+DocumentTermMatrix(
+  [1, 1]  =  1
+  [2, 1]  =  1
+  [1, 2]  =  2
+  [2, 3]  =  2
+  [1, 4]  =  1
+  [2, 4]  =  1
+  [1, 5]  =  1
+  [2, 5]  =  1
+  [1, 6]  =  1
+  [2, 6]  =  1, ["To", "be", "become", "not", "or", "to"], Dict("or"=>5,"not"=>4,"to"=>6,"To"=>1,"be"=>2,"become"=>3))
+
+julia> tf_idf(m)
+2×6 SparseArrays.SparseMatrixCSC{Float64,Int64} with 10 stored entries:
+  [1, 1]  =  0.0
+  [2, 1]  =  0.0
+  [1, 2]  =  0.231049
+  [2, 3]  =  0.231049
+  [1, 4]  =  0.0
+  [2, 4]  =  0.0
+  [1, 5]  =  0.0
+  [2, 5]  =  0.0
+  [1, 6]  =  0.0
+  [2, 6]  =  0.0
+```
 
 As you can see, TF-IDF has the effect of inserting 0's into the columns of
 words that occur in all documents. This is a useful way to avoid having to
@@ -152,4 +213,3 @@ A trained model (using Flux) on IMDB word corpus with weights saved are used to 
 
 *  doc              = Input Document for calculating document (AbstractDocument type)
 *  handle_unknown   = A function for handling unknown words. Should return an array (default (x)->[])
- 

--- a/docs/src/features.md
+++ b/docs/src/features.md
@@ -159,6 +159,8 @@ julia> tf(m)
 
 ## TF-IDF (Term Frequency - Inverse Document Frequency)
 
+    tf_idf(dtm)
+
 In many cases, raw word counts are not appropriate for use because:
 
 * (A) Some documents are longer than other documents

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -39,7 +39,7 @@ function title!(d::AbstractDocument, nv::AbstractString)
 end
 
 """
-    language!(doc, lang)
+    language!(doc, lang::T) where T <: Language
 
 Set the language of `doc` to `lang`.
 
@@ -67,7 +67,7 @@ function author!(d::AbstractDocument, nv::AbstractString)
 end
 
 """
-    author!(doc, timestamp)
+    author!(doc, timestamp::AbstractString)
 
 Set the timestamp metadata of doc to `timestamp`.
 """
@@ -111,7 +111,7 @@ timestamps!(c::Corpus, nv::AbstractString) = timestamp!.(documents(c), Ref(nv))
 
 """
     titles!(crps, vec::Vector{String})
-    titles!(crps, str::String)
+    titles!(crps, str)
 
 Update titles of the documents in a Corpus.
 

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -49,7 +49,7 @@ function title!(d::AbstractDocument, nv::AbstractString)
 end
 
 """
-    language!(doc, lang::T) where T <: Language
+    language!(doc, lang::Language)
 
 Set the language of `doc` to `lang`.
 
@@ -65,7 +65,7 @@ Languages.Spanish()
 
 See also: [`language`](@ref), [`languages`](@ref), [`languages!`](@ref)
 """
-function language!(d::AbstractDocument, nv::T) where T <: Language
+function language!(d::AbstractDocument, nv::Language)
     d.metadata.language = nv
 end
 
@@ -151,8 +151,8 @@ function titles!(c::Corpus, nvs::Vector{String})
 end
 
 """
-    languages!(crps, langs::Vector{T}) where T <: Language
-    languages!(crps, lang::T) where T <: Language
+    languages!(crps, langs::Vector{Language})
+    languages!(crps, lang::Language)
 
 Update languages of documents in a Corpus.
 

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -3,28 +3,28 @@ import Languages.name
 """
     title(doc)
 
-Returns the title metadata for `doc`
+Return the title metadata for `doc`
 """
 title(d::AbstractDocument) = d.metadata.title
 
 """
     language(doc)
 
-Returns the language metadata for `doc`
+Return the language metadata for `doc`
 """
 language(d::AbstractDocument) = d.metadata.language
 
 """
     author(doc)
 
-Returns the author metadata for `doc`
+Return the author metadata for `doc`
 """
 author(d::AbstractDocument) = d.metadata.author
 
 """
     timestamp(doc)
 
-Returns the timestamp metadata for `doc`
+Return the timestamp metadata for `doc`
 """
 timestamp(d::AbstractDocument) = d.metadata.timestamp
 
@@ -32,7 +32,7 @@ timestamp(d::AbstractDocument) = d.metadata.timestamp
 """
     title!(doc, str)
 
-Sets the title of `doc` to `str`
+Set the title of `doc` to `str`
 """
 function title!(d::AbstractDocument, nv::AbstractString)
     d.metadata.title = nv
@@ -41,7 +41,7 @@ end
 """
     language!(doc, lang)
 
-Sets the language of `doc` to `lang`.
+Set the language of `doc` to `lang`.
 
 # Example
 ```julia-repl
@@ -58,18 +58,18 @@ function language!(d::AbstractDocument, nv::T) where T <: Language
 end
 
 """
-    author!(doc, authr)
+    author!(doc, author)
 
-Sets the `author` metadata of doc to `authr`
+Set the author metadata of doc to `author`
 """
 function author!(d::AbstractDocument, nv::AbstractString)
     d.metadata.author = nv
 end
 
 """
-    author!(doc, timestmp)
+    author!(doc, timestamp)
 
-Sets the `timestamp` metadata of doc to `timestmp`
+Set the timestamp metadata of doc to `timestamp`
 """
 function timestamp!(d::AbstractDocument, nv::AbstractString)
     d.metadata.timestamp = nv
@@ -111,9 +111,10 @@ timestamps!(c::Corpus, nv::AbstractString) = timestamp!.(documents(c), Ref(nv))
 
 """
     titles!(crps, ::Vector{String})
-    titles!(crps, str)
+    titles!(crps, str::String)
 
-Updates the titles of the documents in `crps` to the strings in the input vector.
+Update titles of documents in `crps` to the ones in input vector.
+If the input is a String, then set the same title for all documents.
 
 See also: [`title!`](@ref), [`titles`](@ref)
 """
@@ -128,7 +129,7 @@ end
     languages!(crps, langs)
     languages!(crps, lang)
 
-Updates the languages of the documents in `crps` to `langs`, respectively.
+Update the languages of the documents in crps to `langs`.
 """
 function languages!(c::Corpus, nvs::Vector{T}) where T <: Language
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))
@@ -141,7 +142,7 @@ end
     authors!(crps, athrs)
     authors!(crps, athr)
 
-Sets the authors of the documents in `crps` to the `athrs`, respectively.
+Set the authors of the documents in `crps` to the `athrs`, respectively.
 """
 function authors!(c::Corpus, nvs::Vector{String})
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))
@@ -151,10 +152,10 @@ function authors!(c::Corpus, nvs::Vector{String})
 end
 
 """
-    timestamps!(crps, times)
-    timestamps!(crps, time)
+    timestamps!(crps, times ::Vector{String})
+    timestamps!(crps, time::AbstractString)
 
-Sets the timestamps of the documents in `crps` to the timestamps in `times`, respectively .
+Set the timestamps of the documents in `crps` to the timestamps in `times`, respectively.
 """
 function timestamps!(c::Corpus, nvs::Vector{String})
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -3,28 +3,28 @@ import Languages.name
 """
     title(doc)
 
-Return the title metadata for `doc`
+Return the title metadata for `doc`.
 """
 title(d::AbstractDocument) = d.metadata.title
 
 """
     language(doc)
 
-Return the language metadata for `doc`
+Return the language metadata for `doc`.
 """
 language(d::AbstractDocument) = d.metadata.language
 
 """
     author(doc)
 
-Return the author metadata for `doc`
+Return the author metadata for `doc`.
 """
 author(d::AbstractDocument) = d.metadata.author
 
 """
     timestamp(doc)
 
-Return the timestamp metadata for `doc`
+Return the timestamp metadata for `doc`.
 """
 timestamp(d::AbstractDocument) = d.metadata.timestamp
 
@@ -32,7 +32,7 @@ timestamp(d::AbstractDocument) = d.metadata.timestamp
 """
     title!(doc, str)
 
-Set the title of `doc` to `str`
+Set the title of `doc` to `str`.
 """
 function title!(d::AbstractDocument, nv::AbstractString)
     d.metadata.title = nv
@@ -60,7 +60,7 @@ end
 """
     author!(doc, author)
 
-Set the author metadata of doc to `author`
+Set the author metadata of doc to `author`.
 """
 function author!(d::AbstractDocument, nv::AbstractString)
     d.metadata.author = nv
@@ -69,7 +69,7 @@ end
 """
     author!(doc, timestamp)
 
-Set the timestamp metadata of doc to `timestamp`
+Set the timestamp metadata of doc to `timestamp`.
 """
 function timestamp!(d::AbstractDocument, nv::AbstractString)
     d.metadata.timestamp = nv
@@ -79,28 +79,28 @@ end
 """
     titles(crps)
 
-Return the titles for each document in `crps`
+Return the titles for each document in `crps`.
 """
 titles(c::Corpus) = map(d -> title(d), documents(c))
 
 """
     languages(crps)
 
-Return the languages for each document in `crps`
+Return the languages for each document in `crps`.
 """
 languages(c::Corpus) = map(d -> language(d), documents(c))
 
 """
     authors(crps)
 
-Return the authors for each document in `crps`
+Return the authors for each document in `crps`.
 """
 authors(c::Corpus) = map(d -> author(d), documents(c))
 
 """
     timestamps(crps)
 
-Return the timestamps for each document in `crps`
+Return the timestamps for each document in `crps`.
 """
 timestamps(c::Corpus) = map(d -> timestamp(d), documents(c))
 
@@ -110,11 +110,12 @@ authors!(c::Corpus, nv::AbstractString) = author!.(documents(c), Ref(nv))
 timestamps!(c::Corpus, nv::AbstractString) = timestamp!.(documents(c), Ref(nv))
 
 """
-    titles!(crps, ::Vector{String})
+    titles!(crps, vec::Vector{String})
     titles!(crps, str::String)
 
-Update titles of documents in `crps` to the ones in input vector.
-If the input is a String, then set the same title for all documents.
+Update titles of the documents in a Corpus.
+
+If the input is a String, set the same title for all documents. If the input is a vector, set title of `i`th document to corresponding `i`th element in the vector `vec`. In the latter case, the number of documents must equal the length of vector.
 
 See also: [`title!`](@ref), [`titles`](@ref)
 """
@@ -126,10 +127,14 @@ function titles!(c::Corpus, nvs::Vector{String})
 end
 
 """
-    languages!(crps, langs)
-    languages!(crps, lang)
+    languages!(crps, langs::Vector{T}) where T <: Language
+    languages!(crps, lang::T) where T <: Language
 
-Update the languages of the documents in crps to `langs`.
+Update languages of documents in a Corpus.
+
+If the input is a Vector, then language of the `i`th document is set to the `i`th element in the vector, respectively. However, the number of documents must equal the length of vector.
+
+See also: [`language!`](@ref), [`languages`](@ref)
 """
 function languages!(c::Corpus, nvs::Vector{T}) where T <: Language
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))
@@ -152,7 +157,7 @@ function authors!(c::Corpus, nvs::Vector{String})
 end
 
 """
-    timestamps!(crps, times ::Vector{String})
+    timestamps!(crps, times::Vector{String})
     timestamps!(crps, time::AbstractString)
 
 Set the timestamps of the documents in `crps` to the timestamps in `times`, respectively.

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -1,41 +1,107 @@
-##############################################################################
-#
-# Metadata field getters and setters
-#
-##############################################################################
-
 import Languages.name
 
+"""
+    title(doc)
+
+Returns the title metadata for `doc`
+"""
 title(d::AbstractDocument) = d.metadata.title
+
+"""
+    language(doc)
+
+Returns the language metadata for `doc`
+"""
 language(d::AbstractDocument) = d.metadata.language
+
+"""
+    author(doc)
+
+Returns the author metadata for `doc`
+"""
 author(d::AbstractDocument) = d.metadata.author
+
+"""
+    timestamp(doc)
+
+Returns the timestamp metadata for `doc`
+"""
 timestamp(d::AbstractDocument) = d.metadata.timestamp
 
+
+"""
+    title!(doc, str)
+
+Sets the title of `doc` to `str`
+"""
 function title!(d::AbstractDocument, nv::AbstractString)
     d.metadata.title = nv
 end
 
+"""
+    language!(doc, lang)
+
+Sets the language of `doc` to `lang`.
+
+# Example
+```julia-repl
+julia> d = StringDocument("String Document 1")
+
+julia> language!(d, Languages.Spanish())
+
+julia> d.metadata.language
+Languages.Spanish()
+```
+"""
 function language!(d::AbstractDocument, nv::T) where T <: Language
     d.metadata.language = nv
 end
 
+"""
+    author!(doc, authr)
+
+Sets the `author` metadata of doc to `authr`
+"""
 function author!(d::AbstractDocument, nv::AbstractString)
     d.metadata.author = nv
 end
 
+"""
+    author!(doc, timestmp)
+
+Sets the `timestamp` metadata of doc to `timestmp`
+"""
 function timestamp!(d::AbstractDocument, nv::AbstractString)
     d.metadata.timestamp = nv
 end
 
-##############################################################################
-#
-# Vectorized getters for an entire Corpus
-#
-##############################################################################
 
+"""
+    titles(crps)
+
+Return the titles for each document in `crps`
+"""
 titles(c::Corpus) = map(d -> title(d), documents(c))
+
+"""
+    languages(crps)
+
+Return the languages for each document in `crps`
+"""
 languages(c::Corpus) = map(d -> language(d), documents(c))
+
+"""
+    authors(crps)
+
+Return the authors for each document in `crps`
+"""
 authors(c::Corpus) = map(d -> author(d), documents(c))
+
+"""
+    timestamps(crps)
+
+Return the timestamps for each document in `crps`
+"""
 timestamps(c::Corpus) = map(d -> timestamp(d), documents(c))
 
 titles!(c::Corpus, nv::AbstractString) = title!.(documents(c), nv)
@@ -43,6 +109,14 @@ languages!(c::Corpus, nv::T) where {T <: Language} = language!.(documents(c), Re
 authors!(c::Corpus, nv::AbstractString) = author!.(documents(c), Ref(nv))
 timestamps!(c::Corpus, nv::AbstractString) = timestamp!.(documents(c), Ref(nv))
 
+"""
+    titles!(crps, ::Vector{String})
+    titles!(crps, str)
+
+Updates the titles of the documents in `crps` to the strings in the input vector.
+
+See also: [`title!`](@ref), [`titles`](@ref)
+"""
 function titles!(c::Corpus, nvs::Vector{String})
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))
     for (i, d) in pairs(IndexLinear(), documents(c))
@@ -50,6 +124,12 @@ function titles!(c::Corpus, nvs::Vector{String})
     end
 end
 
+"""
+    languages!(crps, langs)
+    languages!(crps, lang)
+
+Updates the languages of the documents in `crps` to `langs`, respectively.
+"""
 function languages!(c::Corpus, nvs::Vector{T}) where T <: Language
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))
     for (i, d) in pairs(IndexLinear(), documents(c))
@@ -57,6 +137,12 @@ function languages!(c::Corpus, nvs::Vector{T}) where T <: Language
     end
 end
 
+"""
+    authors!(crps, athrs)
+    authors!(crps, athr)
+
+Sets the authors of the documents in `crps` to the `athrs`, respectively.
+"""
 function authors!(c::Corpus, nvs::Vector{String})
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))
     for (i, d) in pairs(IndexLinear(), documents(c))
@@ -64,6 +150,12 @@ function authors!(c::Corpus, nvs::Vector{String})
     end
 end
 
+"""
+    timestamps!(crps, times)
+    timestamps!(crps, time)
+
+Sets the timestamps of the documents in `crps` to the timestamps in `times`, respectively .
+"""
 function timestamps!(c::Corpus, nvs::Vector{String})
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))
     for (i, d) in pairs(IndexLinear(), documents(c))

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -4,6 +4,8 @@ import Languages.name
     title(doc)
 
 Return the title metadata for `doc`.
+
+See also: [`title!`](@ref), [`titles`](@ref), [`titles!`](@ref)
 """
 title(d::AbstractDocument) = d.metadata.title
 
@@ -11,6 +13,8 @@ title(d::AbstractDocument) = d.metadata.title
     language(doc)
 
 Return the language metadata for `doc`.
+
+See also: [`language!`](@ref), [`languages`](@ref), [`languages!`](@ref)
 """
 language(d::AbstractDocument) = d.metadata.language
 
@@ -18,6 +22,8 @@ language(d::AbstractDocument) = d.metadata.language
     author(doc)
 
 Return the author metadata for `doc`.
+
+See also: [`author!`](@ref), [`authors`](@ref), [`authors!`](@ref)
 """
 author(d::AbstractDocument) = d.metadata.author
 
@@ -25,6 +31,8 @@ author(d::AbstractDocument) = d.metadata.author
     timestamp(doc)
 
 Return the timestamp metadata for `doc`.
+
+See also: [`timestamp!`](@ref), [`timestamps`](@ref), [`timestamps!`](@ref)
 """
 timestamp(d::AbstractDocument) = d.metadata.timestamp
 
@@ -33,6 +41,8 @@ timestamp(d::AbstractDocument) = d.metadata.timestamp
     title!(doc, str)
 
 Set the title of `doc` to `str`.
+
+See also: [`title`](@ref), [`titles`](@ref), [`titles!`](@ref)
 """
 function title!(d::AbstractDocument, nv::AbstractString)
     d.metadata.title = nv
@@ -52,6 +62,8 @@ julia> language!(d, Languages.Spanish())
 julia> d.metadata.language
 Languages.Spanish()
 ```
+
+See also: [`language`](@ref), [`languages`](@ref), [`languages!`](@ref)
 """
 function language!(d::AbstractDocument, nv::T) where T <: Language
     d.metadata.language = nv
@@ -61,15 +73,19 @@ end
     author!(doc, author)
 
 Set the author metadata of doc to `author`.
+
+See also: [`author`](@ref), [`authors`](@ref), [`authors!`](@ref)
 """
 function author!(d::AbstractDocument, nv::AbstractString)
     d.metadata.author = nv
 end
 
 """
-    author!(doc, timestamp::AbstractString)
+    timestamp!(doc, timestamp::AbstractString)
 
 Set the timestamp metadata of doc to `timestamp`.
+
+See also: [`timestamp`](@ref), [`timestamps`](@ref), [`timestamps!`](@ref)
 """
 function timestamp!(d::AbstractDocument, nv::AbstractString)
     d.metadata.timestamp = nv
@@ -80,6 +96,8 @@ end
     titles(crps)
 
 Return the titles for each document in `crps`.
+
+See also: [`titles!`](@ref), [`title`](@ref), [`title!`](@ref)
 """
 titles(c::Corpus) = map(d -> title(d), documents(c))
 
@@ -87,6 +105,8 @@ titles(c::Corpus) = map(d -> title(d), documents(c))
     languages(crps)
 
 Return the languages for each document in `crps`.
+
+See also: [`languages!`](@ref), [`language`](@ref), [`language!`](@ref)
 """
 languages(c::Corpus) = map(d -> language(d), documents(c))
 
@@ -94,6 +114,8 @@ languages(c::Corpus) = map(d -> language(d), documents(c))
     authors(crps)
 
 Return the authors for each document in `crps`.
+
+See also: [`authors!`](@ref), [`author`](@ref), [`author!`](@ref)
 """
 authors(c::Corpus) = map(d -> author(d), documents(c))
 
@@ -101,6 +123,8 @@ authors(c::Corpus) = map(d -> author(d), documents(c))
     timestamps(crps)
 
 Return the timestamps for each document in `crps`.
+
+See also: [`timestamps!`](@ref), [`timestamp`](@ref), [`timestamp!`](@ref)
 """
 timestamps(c::Corpus) = map(d -> timestamp(d), documents(c))
 
@@ -117,7 +141,7 @@ Update titles of the documents in a Corpus.
 
 If the input is a String, set the same title for all documents. If the input is a vector, set title of `i`th document to corresponding `i`th element in the vector `vec`. In the latter case, the number of documents must equal the length of vector.
 
-See also: [`title!`](@ref), [`titles`](@ref)
+See also: [`titles`](@ref), [`title!`](@ref), [`title`](@ref)
 """
 function titles!(c::Corpus, nvs::Vector{String})
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))
@@ -134,7 +158,7 @@ Update languages of documents in a Corpus.
 
 If the input is a Vector, then language of the `i`th document is set to the `i`th element in the vector, respectively. However, the number of documents must equal the length of vector.
 
-See also: [`language!`](@ref), [`languages`](@ref)
+See also: [`languages`](@ref), [`language!`](@ref), [`language`](@ref)
 """
 function languages!(c::Corpus, nvs::Vector{T}) where T <: Language
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))
@@ -148,6 +172,8 @@ end
     authors!(crps, athr)
 
 Set the authors of the documents in `crps` to the `athrs`, respectively.
+
+See also: [`authors`](@ref), [`author!`](@ref), [`author`](@ref)
 """
 function authors!(c::Corpus, nvs::Vector{String})
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))
@@ -161,6 +187,8 @@ end
     timestamps!(crps, time::AbstractString)
 
 Set the timestamps of the documents in `crps` to the timestamps in `times`, respectively.
+
+See also: [`timestamps`](@ref), [`timestamp!`](@ref), [`timestamp`](@ref)
 """
 function timestamps!(c::Corpus, nvs::Vector{String})
     length(c) == length(nvs) || throw(DimensionMismatch("dimensions must match"))

--- a/src/ngramizer.jl
+++ b/src/ngramizer.jl
@@ -1,9 +1,10 @@
 """
     ngramize(lang, tokens, n)
 
+Compute the ngrams of `tokens` of the order `n`.
 
-Returns the ngrams of `tokens` with order of `n`.
 # Example
+
 ```julia-repl
 julia> ngramize(Languages.English(), ["To", "be", "or", "not", "to"], 3)
 Dict{AbstractString,Int64} with 3 entries:
@@ -29,7 +30,7 @@ end
 """
     onegramize(lang, tokens)
 
-Returns the unigrams dict for the input `tokens`
+Create the unigrams dict for input tokens
 
 # Example
 

--- a/src/ngramizer.jl
+++ b/src/ngramizer.jl
@@ -30,7 +30,7 @@ end
 """
     onegramize(lang, tokens)
 
-Create the unigrams dict for input tokens
+Create the unigrams dict for input tokens.
 
 # Example
 

--- a/src/ngramizer.jl
+++ b/src/ngramizer.jl
@@ -1,9 +1,17 @@
-##############################################################################
-#
-# Construct n-grams using single space concatenation
-#
-##############################################################################
+"""
+    ngramize(lang, tokens, n)
 
+
+Returns the ngrams of `tokens` with order of `n`.
+# Example
+```julia-repl
+julia> ngramize(Languages.English(), ["To", "be", "or", "not", "to"], 3)
+Dict{AbstractString,Int64} with 3 entries:
+  "be or not" => 1
+  "or not to" => 1
+  "To be or"  => 1
+```
+"""
 function ngramize(lang::S, words::Vector{T}, n::Int) where {S <: Language, T <: AbstractString}
     (n == 1) && return onegramize(lang, words)
 
@@ -14,12 +22,27 @@ function ngramize(lang::S, words::Vector{T}, n::Int) where {S <: Language, T <: 
     for index in 1:(n_words - n + 1)
         token = join(words[index:(index + n - 1)], " ")
         tokens[token] = get(tokens, token, 0) + 1
-       
     end
-
     return tokens
 end
 
+"""
+    onegramize(lang, tokens)
+
+Returns the unigrams dict for the input `tokens`
+
+# Example
+
+```julia-repl
+julia> onegramize(Languages.English(), ["To", "be", "or", "not", "to", "be"])
+Dict{String,Int64} with 5 entries:
+  "or"  => 1
+  "not" => 1
+  "to"  => 1
+  "To"  => 1
+  "be"  => 2
+```
+"""
 function onegramize(lang::S, words::Vector{T}) where {S <: Language, T <: AbstractString}
     n_words = length(words)
     tokens = Dict{T, Int}()
@@ -28,5 +51,5 @@ function onegramize(lang::S, words::Vector{T}) where {S <: Language, T <: Abstra
         tokens[word] = get(tokens, word, 0) + 1
     end
 
-    tokens
+    return tokens
 end

--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -56,6 +56,7 @@ remove_corrupt_utf8!(d::FileDocument) = error("FileDocument cannot be modified")
     remove_corrupt_utf8!(crps)
 
 Remove corrupt UTF8 characters for `doc` or documents in `crps`.
+
 Does not support `FileDocument` or Corpus containing `FileDocument`.
 """
 function remove_corrupt_utf8!(d::StringDocument)
@@ -106,6 +107,7 @@ remove_case(s::T) where {T <: AbstractString} = lowercase(s)
     remove_case!(crps::Corpus)
 
 Convert the text of `doc` or `crps` to lowercase.
+
 Does not support `FileDocument` or `crps` containing `FileDocument`.
 
 # Example
@@ -175,6 +177,7 @@ end
     remove_html_tags!(crps::Corpus)
 
 Remove html tags from the `StringDocument` or documents `crps`.
+
 Does not work for documents other than `StringDocument`.
 
 # Example
@@ -251,8 +254,7 @@ tag_pos!(entity) = error("Not yet implemented")
 """
     sparse_terms(crps [, alpha])
 
-Find the sparse terms from Corpus, occuring in less than `alpha` percentage of the documents.
-`alpha = 0.05` by default.
+Find the sparse terms from Corpus, occuring in less than `alpha` percentage of the documents, with `alpha = 0.05` by default.
 
 # Example
 
@@ -286,8 +288,7 @@ end
 """
     frequent_terms(crps [, alpha])
 
-Find the frequent terms from Corpus, occuring more than `alpha` percentage of the documents.
-`alpha = 0.05` by default.
+Find the frequent terms from Corpus, occuring more than `alpha` percentage of the documents, with `alpha = 0.05` by default.
 
 # Example
 
@@ -322,8 +323,9 @@ end
 """
     remove_sparse_terms!(crps [, alpha])
 
-Remove sparse terms in crps, occuring less than `alpha` percent of documents.
-`alpha` defaults to 0.05.
+Remove sparse terms in crps, occuring less than `alpha` percent of documents, `alpha` defaults to 0.05.
+
+# Example
 
 ```julia-repl
 julia> crps = Corpus([StringDocument("This is Document 1"),
@@ -343,8 +345,9 @@ remove_sparse_terms!(crps::Corpus, alpha::Real = alpha_sparse) = remove_words!(c
 """
     remove_frequent_terms!(crps [, alpha])
 
-Remove terms in `crps`, occuring more than `alpha` percent of documents.
-`alpha` defaults to 0.95.
+Remove terms in `crps`, occuring more than `alpha` percent of documents, `alpha` defaults to 0.95.
+
+# Example
 
 ```julia-repl
 julia> crps = Corpus([StringDocument("This is Document 1"),
@@ -450,8 +453,7 @@ remove_whitespace(s::AbstractString) = replace(strip(s), r"\s+"=>" ")
     remove_whitespace!(doc)
     remove_whitespace!(crps)
 
-Squash multiple whitespaces to a single space.
-And remove all leading and trailing whitespaces in document or crps.
+Squash multiple whitespaces to a single space and remove all leading and trailing whitespaces in document or crps.
 
 Does no-op for `FileDocument`, `TokenDocument` or `NGramDocument`.
 """

--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -37,7 +37,7 @@ end
 
 
 """
-    remove_corrupt_utf8(str::AbstractString)
+    remove_corrupt_utf8(str)
 
 Remove corrupt UTF8 characters in `str`.
 
@@ -50,9 +50,7 @@ end
 remove_corrupt_utf8!(d::FileDocument) = error("FileDocument cannot be modified")
 
 """
-    remove_corrupt_utf8!(doc::StringDocument)
-    remove_corrupt_utf8!(doc::TokenDocument)
-    remove_corrupt_utf8!(doc::NGramDocument)
+    remove_corrupt_utf8!(doc)
     remove_corrupt_utf8!(crps)
 
 Remove corrupt UTF8 characters for `doc` or documents in `crps`.
@@ -90,7 +88,7 @@ function remove_corrupt_utf8!(crps::Corpus)
 end
 
 """
-    remove_case(str::AbstractString)
+    remove_case(str)
 
 Convert `str` to lowercase.
 
@@ -100,11 +98,8 @@ remove_case(s::T) where {T <: AbstractString} = lowercase(s)
 
 
 """
-    remove_case!(doc::TokenDocument)
-    remove_case!(doc::StringDocument)
-    remove_case!(doc::NGramDocument)
-
-    remove_case!(crps::Corpus)
+    remove_case!(doc)
+    remove_case!(crps)
 
 Convert the text of `doc` or `crps` to lowercase.
 
@@ -160,7 +155,7 @@ const style_tags = Regex("<style\\b[^>]*>([\\s\\S]*?)</style>")
 const html_tags = Regex("<[^>]*>")
 
 """
-    remove_html_tags(str::AbstractString)
+    remove_html_tags(str)
 
 Remove html tags from `str`, including the style and script tags.
 
@@ -174,7 +169,7 @@ end
 
 """
     remove_html_tags!(doc::StringDocument)
-    remove_html_tags!(crps::Corpus)
+    remove_html_tags!(crps)
 
 Remove html tags from the `StringDocument` or documents `crps`.
 
@@ -218,8 +213,8 @@ end
 
 
 """
-    remove_words!(doc::AbstractDocument, words::Vector)
-    remove_words!(crps::Corpus, words::Vector)
+    remove_words!(doc, words::Vector{T}) where T <: AbstractString
+    remove_words!(crps, words::Vector{T}) where T <: AbstractString
 
 Remove the occurences of words from `doc` or `crps`.
 
@@ -252,9 +247,9 @@ end
 tag_pos!(entity) = error("Not yet implemented")
 
 """
-    sparse_terms(crps [, alpha])
+    sparse_terms(crps, alpha=0.05])
 
-Find the sparse terms from Corpus, occuring in less than `alpha` percentage of the documents, with `alpha = 0.05` by default.
+Find the sparse terms from Corpus, occuring in less than `alpha` percentage of the documents.
 
 # Example
 
@@ -286,9 +281,9 @@ function sparse_terms(crps::Corpus, alpha::Real = alpha_sparse)
 end
 
 """
-    frequent_terms(crps [, alpha])
+    frequent_terms(crps, alpha=0.95)
 
-Find the frequent terms from Corpus, occuring more than `alpha` percentage of the documents, with `alpha = 0.05` by default.
+Find the frequent terms from Corpus, occuring more than `alpha` percentage of the documents.
 
 # Example
 
@@ -321,9 +316,9 @@ function frequent_terms(crps::Corpus, alpha::Real = alpha_frequent)
 end
 
 """
-    remove_sparse_terms!(crps [, alpha])
+    remove_sparse_terms!(crps, alpha=0.05)
 
-Remove sparse terms in crps, occuring less than `alpha` percent of documents, `alpha` defaults to 0.05.
+Remove sparse terms in crps, occuring less than `alpha` percent of documents.
 
 # Example
 
@@ -343,9 +338,9 @@ See also: [`remove_frequent_terms!`](@ref), [`sparse_terms`](@ref)
 remove_sparse_terms!(crps::Corpus, alpha::Real = alpha_sparse) = remove_words!(crps, sparse_terms(crps, alpha))
 
 """
-    remove_frequent_terms!(crps [, alpha])
+    remove_frequent_terms!(crps, alpha=0.95)
 
-Remove terms in `crps`, occuring more than `alpha` percent of documents, `alpha` defaults to 0.95.
+Remove terms in `crps`, occuring more than `alpha` percent of documents.
 
 # Example
 
@@ -439,14 +434,14 @@ end
 
 
 """
-    remove_whitespace(s::AbstractString)
+    remove_whitespace(str)
 
 Squash multiple whitespaces to a single one.
 And remove all leading and trailing whitespaces.
 
 See also: [`remove_whitespace!`](@ref)
 """
-remove_whitespace(s::AbstractString) = replace(strip(s), r"\s+"=>" ")
+remove_whitespace(str::AbstractString) = replace(strip(str), r"\s+"=>" ")
 
 
 """

--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -219,8 +219,8 @@ end
 
 
 """
-    remove_words!(doc, words::Vector{T}) where T <: AbstractString
-    remove_words!(crps, words::Vector{T}) where T <: AbstractString
+    remove_words!(doc, words::Vector{AbstractString})
+    remove_words!(crps, words::Vector{AbstractString})
 
 Remove the occurences of words from `doc` or `crps`.
 

--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -112,7 +112,12 @@ Does not support `FileDocument` or `crps` containing `FileDocument`.
 ```julia-repl
 julia> str = "The quick brown fox jumps over the lazy dog"
 julia> sd = StringDocument(str)
-StringDocument{String}("The quick brown fox jumps over the lazy dog", TextAnalysis.DocumentMetadata(Languages.English(), "Untitled Document", "Unknown Author", "Unknown Time"))
+A StringDocument{String}
+ * Language: Languages.English()
+ * Title: Untitled Document
+ * Author: Unknown Author
+ * Timestamp: Unknown Time
+ * Snippet: The quick brown fox jumps over the lazy dog
 
 julia> remove_case!(sd)
 julia> sd.text
@@ -192,7 +197,12 @@ julia> html_doc = StringDocument(
                </html>
              "
             )
-StringDocument{String}("<html>\n            <head><script language=\"javascript\">x = 20;</script></head>\n            <body>\n                <h1>Hello</h1><a href=\"world\">world</a>\n            </body>\n        </html>\n      ", TextAnalysis.DocumentMetadata(Languages.English(), "Untitled Document", "Unknown Author", "Unknown Time"))
+A StringDocument{String}
+ * Language: Languages.English()
+ * Title: Untitled Document
+ * Author: Unknown Author
+ * Timestamp: Unknown Time
+ * Snippet:  <html> <head><s
 
 julia> remove_html_tags!(html_doc)
 
@@ -262,7 +272,14 @@ Find the sparse terms from Corpus, occuring in less than `alpha` percentage of t
 ```
 julia> crps = Corpus([StringDocument("This is Document 1"),
                       StringDocument("This is Document 2")])
-Corpus{StringDocument{String}}(StringDocument{String}[StringDocument{String}("This is Document 1", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time")), StringDocument{String}("This is Document 2", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time"))], 0, Dict{String,Int64}(), Dict{String,Array{Int64,1}}(), TextHashFunction(hash, 100))
+A Corpus with 2 documents:
+* 2 StringDocument's
+* 0 FileDocument's
+* 0 TokenDocument's
+* 0 NGramDocument's
+
+Corpus's lexicon contains 0 tokens
+Corpus's index contains 0 tokens
 
 julia> sparse_terms(crps, 0.5)
 2-element Array{String,1}:
@@ -296,7 +313,14 @@ Find the frequent terms from Corpus, occuring more than `alpha` percentage of th
 ```
 julia> crps = Corpus([StringDocument("This is Document 1"),
                       StringDocument("This is Document 2")])
-Corpus{StringDocument{String}}(StringDocument{String}[StringDocument{String}("This is Document 1", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time")), StringDocument{String}("This is Document 2", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time"))], 0, Dict{String,Int64}(), Dict{String,Array{Int64,1}}(), TextHashFunction(hash, 100))
+A Corpus with 2 documents:
+ * 2 StringDocument's
+ * 0 FileDocument's
+ * 0 TokenDocument's
+ * 0 NGramDocument's
+
+Corpus's lexicon contains 0 tokens
+Corpus's index contains 0 tokens
 
 julia> frequent_terms(crps)
 3-element Array{String,1}:
@@ -331,12 +355,22 @@ Remove sparse terms in crps, occuring less than `alpha` percent of documents.
 ```julia-repl
 julia> crps = Corpus([StringDocument("This is Document 1"),
                       StringDocument("This is Document 2")])
-Corpus{StringDocument{String}}(StringDocument{String}[StringDocument{String}("This is Document 1", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time")), StringDocument{String}("This is Document 2", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time"))], 0, Dict{String,Int64}(), Dict{String,Array{Int64,1}}(), TextHashFunction(hash, 100))
+A Corpus with 2 documents:
+ * 2 StringDocument's
+ * 0 FileDocument's
+ * 0 TokenDocument's
+ * 0 NGramDocument's
+
+Corpus's lexicon contains 0 tokens
+Corpus's index contains 0 tokens
 
 julia> remove_sparse_terms!(crps, 0.5)
 
-julia> crps
-Corpus{StringDocument{String}}(StringDocument{String}[StringDocument{String}("This is Document ", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time")), StringDocument{String}("This is Document ", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time"))], 8, Dict("1"=>1,"is"=>2,"This"=>2,"2"=>1,"Document"=>2), Dict("1"=>[1],"is"=>[1, 2],"This"=>[1, 2],"2"=>[2],"Document"=>[1, 2]), TextHashFunction(hash, 100))
+julia> crps[1].text
+"This is Document "
+
+julia> crps[2].text
+"This is Document "
 ```
 
 See also: [`remove_frequent_terms!`](@ref), [`sparse_terms`](@ref)
@@ -353,12 +387,22 @@ Remove terms in `crps`, occuring more than `alpha` percent of documents.
 ```julia-repl
 julia> crps = Corpus([StringDocument("This is Document 1"),
                       StringDocument("This is Document 2")])
-Corpus{StringDocument{String}}(StringDocument{String}[StringDocument{String}("This is Document 1", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time")), StringDocument{String}("This is Document 2", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time"))], 0, Dict{String,Int64}(), Dict{String,Array{Int64,1}}(), TextHashFunction(hash, 100))
+A Corpus with 2 documents:
+* 2 StringDocument's
+* 0 FileDocument's
+* 0 TokenDocument's
+* 0 NGramDocument's
+
+Corpus's lexicon contains 0 tokens
+Corpus's index contains 0 tokens
 
 julia> remove_frequent_terms!(crps)
 
-julia> crps
-Corpus{StringDocument{String}}(StringDocument{String}[StringDocument{String}("     1", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time")), StringDocument{String}("     2", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time"))], 8, Dict("1"=>1,"is"=>2,"This"=>2,"2"=>1,"Document"=>2), Dict("1"=>[1],"is"=>[1, 2],"This"=>[1, 2],"2"=>[2],"Document"=>[1, 2]), TextHashFunction(hash, 100))
+julia> text(crps[1])
+"     1"
+
+julia> text(crps[2])
+"     2"
 ```
 
 See also: [`remove_sparse_terms!`](@ref), [`frequent_terms`](@ref)
@@ -397,12 +441,17 @@ Preprocess document or corpus based on the input flags.
 
 ```julia-repl
 julia> doc = StringDocument("This is a document of mine")
-StringDocument{String}("This is a document of mine", TextAnalysis.DocumentMetadata(Languages.English(), "Untitled Document", "Unknown Author", "Unknown Time"))
+A StringDocument{String}
+ * Language: Languages.English()
+ * Title: Untitled Document
+ * Author: Unknown Author
+ * Timestamp: Unknown Time
+ * Snippet: This is a document of mine
 
 julia> prepare!(doc, strip_pronouns | strip_articles)
 
-julia> doc
-StringDocument{String}("This is   document of ", TextAnalysis.DocumentMetadata(Languages.English(), "Untitled Document", "Unknown Author", "Unknown Time"))
+julia> text(doc)
+"This is   document of "
 ```
 """
 function prepare!(crps::Corpus, flags::UInt32; skip_patterns = Set{AbstractString}(), skip_words = Set{AbstractString}())

--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -56,6 +56,8 @@ remove_corrupt_utf8!(d::FileDocument) = error("FileDocument cannot be modified")
 Remove corrupt UTF8 characters for `doc` or documents in `crps`.
 
 Does not support `FileDocument` or Corpus containing `FileDocument`.
+
+See also: [`remove_corrupt_utf8`](@ref)
 """
 function remove_corrupt_utf8!(d::StringDocument)
     d.text = remove_corrupt_utf8(d.text)
@@ -116,6 +118,8 @@ julia> remove_case!(sd)
 julia> sd.text
 "the quick brown fox jumps over the lazy dog"
 ```
+
+See also: [`remove_case`](@ref)
 """
 remove_case!(d::FileDocument) = error("FileDocument cannot be modified")
 
@@ -195,6 +199,8 @@ julia> remove_html_tags!(html_doc)
 julia> strip(text(html_doc))
 "Hello world"
 ```
+
+See also: [`remove_html_tags`](@ref)
 """
 function remove_html_tags!(d::AbstractDocument)
     error("HTML tags can be removed only from a StringDocument")
@@ -451,6 +457,8 @@ remove_whitespace(str::AbstractString) = replace(strip(str), r"\s+"=>" ")
 Squash multiple whitespaces to a single space and remove all leading and trailing whitespaces in document or crps.
 
 Does no-op for `FileDocument`, `TokenDocument` or `NGramDocument`.
+
+See also: [`remove_whitespace`](@ref)
 """
 function remove_whitespace!(d::StringDocument)
     d.text = remove_whitespace(d.text)
@@ -505,6 +513,8 @@ end
 Remove patterns matched by `rex` in document or Corpus.
 
 Does not modify `FileDocument` or Corpus containing `FileDocument`.
+
+See also: [`remove_patterns`](@ref)
 """
 remove_patterns!(d::FileDocument, rex::Regex) = error("FileDocument cannot be modified")
 

--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -39,7 +39,7 @@ end
 """
     remove_corrupt_utf8(str::AbstractString)
 
-Returns the string after removeing the corrupt UTF8 characters in `str`.
+Remove corrupt UTF8 characters in `str`.
 
 See also: [`remove_corrupt_utf8!`](@ref)
 """
@@ -55,8 +55,8 @@ remove_corrupt_utf8!(d::FileDocument) = error("FileDocument cannot be modified")
     remove_corrupt_utf8!(doc::NGramDocument)
     remove_corrupt_utf8!(crps)
 
-Removes corrupt UTF8 characters for `doc` or each document in `crps`.
-This is not supported for `FileDocument`, or `crps` containing `FileDocument`.
+Remove corrupt UTF8 characters for `doc` or documents in `crps`.
+Does not support `FileDocument` or Corpus containing `FileDocument`.
 """
 function remove_corrupt_utf8!(d::StringDocument)
     d.text = remove_corrupt_utf8(d.text)
@@ -89,9 +89,9 @@ function remove_corrupt_utf8!(crps::Corpus)
 end
 
 """
-    remove_case(s::AbstractString)
+    remove_case(str::AbstractString)
 
-Converts the string to lowercase.
+Convert `str` to lowercase.
 
 See also: [`remove_case!`](@ref)
 """
@@ -99,14 +99,14 @@ remove_case(s::T) where {T <: AbstractString} = lowercase(s)
 
 
 """
-    remove_case!(d::TokenDocument)
-    remove_case!(d::StringDocument)
-    remove_case!(d::NGramDocument)
+    remove_case!(doc::TokenDocument)
+    remove_case!(doc::StringDocument)
+    remove_case!(doc::NGramDocument)
 
-    remove_case!(c::Corpus)
+    remove_case!(crps::Corpus)
 
-Converts the text of the document or corpus to lowercase. This method does not
-works with FileDocument.
+Convert the text of `doc` or `crps` to lowercase.
+Does not support `FileDocument` or `crps` containing `FileDocument`.
 
 # Example
 
@@ -158,9 +158,9 @@ const style_tags = Regex("<style\\b[^>]*>([\\s\\S]*?)</style>")
 const html_tags = Regex("<[^>]*>")
 
 """
-    remove_html_tags(s::AbstractString)
+    remove_html_tags(str::AbstractString)
 
-Removes the html tags from string, including the style and script tags.
+Remove html tags from `str`, including the style and script tags.
 
 See also: [`remove_html_tags!`](@ref)
 """
@@ -174,7 +174,8 @@ end
     remove_html_tags!(doc::StringDocument)
     remove_html_tags!(crps::Corpus)
 
-Removes the html tags from the `StringDocument` or all the documents in `crps`. This is supported only for StringDocument or Corpus made of these documents.
+Remove html tags from the `StringDocument` or documents `crps`.
+Does not work for documents other than `StringDocument`.
 
 # Example
 
@@ -214,10 +215,10 @@ end
 
 
 """
-    remove_words!(d::AbstractDocument, words::Vector)
-    remove_words!(c::Corpus, words::Vector)
+    remove_words!(doc::AbstractDocument, words::Vector)
+    remove_words!(crps::Corpus, words::Vector)
 
-Removes the tokens defined in the list `words` from the source Document or Corpus
+Remove the occurences of words from `doc` or `crps`.
 
 # Example
 
@@ -250,8 +251,8 @@ tag_pos!(entity) = error("Not yet implemented")
 """
     sparse_terms(crps [, alpha])
 
-Returns an array of the terms in `crps` occuring in less than `alpha` percentage
-of the documents in the corpus, defaults to `alpha = 0.05`
+Find the sparse terms from Corpus, occuring in less than `alpha` percentage of the documents.
+`alpha = 0.05` by default.
 
 # Example
 
@@ -285,8 +286,8 @@ end
 """
     frequent_terms(crps [, alpha])
 
-Returns an array of the terms in `crps` occuring in more than `alpha` percent
-of the documents in the corpus, defaults to `alpha = 0.95`
+Find the frequent terms from Corpus, occuring more than `alpha` percentage of the documents.
+`alpha = 0.05` by default.
 
 # Example
 
@@ -321,8 +322,8 @@ end
 """
     remove_sparse_terms!(crps [, alpha])
 
-Removes the sparse terms in `crps`, occuring less than `alpha` percent
-of all the documents in the Corpus. `alpha` defaults to 0.05.
+Remove sparse terms in crps, occuring less than `alpha` percent of documents.
+`alpha` defaults to 0.05.
 
 ```julia-repl
 julia> crps = Corpus([StringDocument("This is Document 1"),
@@ -340,20 +341,20 @@ See also: [`remove_frequent_terms!`](@ref), [`sparse_terms`](@ref)
 remove_sparse_terms!(crps::Corpus, alpha::Real = alpha_sparse) = remove_words!(crps, sparse_terms(crps, alpha))
 
 """
-    remove_sparse_terms!(crps [, alpha])
+    remove_frequent_terms!(crps [, alpha])
 
-Removes the terms in `crps`, occuring in more than `alpha` percent
-of all the documents in the Corpus. `alpha` defaults to 0.95.
+Remove terms in `crps`, occuring more than `alpha` percent of documents.
+`alpha` defaults to 0.95.
 
 ```julia-repl
 julia> crps = Corpus([StringDocument("This is Document 1"),
                       StringDocument("This is Document 2")])
 Corpus{StringDocument{String}}(StringDocument{String}[StringDocument{String}("This is Document 1", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time")), StringDocument{String}("This is Document 2", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time"))], 0, Dict{String,Int64}(), Dict{String,Array{Int64,1}}(), TextHashFunction(hash, 100))
 
-julia> remove_sparse_terms!(crps, 0.5)
+julia> remove_frequent_terms!(crps)
 
 julia> crps
-Corpus{StringDocument{String}}(StringDocument{String}[StringDocument{String}("This is Document ", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time")), StringDocument{String}("This is Document ", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time"))], 8, Dict("1"=>1,"is"=>2,"This"=>2,"2"=>1,"Document"=>2), Dict("1"=>[1],"is"=>[1, 2],"This"=>[1, 2],"2"=>[2],"Document"=>[1, 2]), TextHashFunction(hash, 100))
+Corpus{StringDocument{String}}(StringDocument{String}[StringDocument{String}("     1", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time")), StringDocument{String}("     2", DocumentMetadata(English(), "Untitled Document", "Unknown Author", "Unknown Time"))], 8, Dict("1"=>1,"is"=>2,"This"=>2,"2"=>1,"Document"=>2), Dict("1"=>[1],"is"=>[1, 2],"This"=>[1, 2],"2"=>[2],"Document"=>[1, 2]), TextHashFunction(hash, 100))
 ```
 
 See also: [`remove_sparse_terms!`](@ref), [`frequent_terms`](@ref)
@@ -365,7 +366,7 @@ remove_frequent_terms!(crps::Corpus, alpha::Real = alpha_frequent) = remove_word
     prepare!(doc, flags)
     prepare!(crps, flags)
 
-Preprocess `doc` or all the documents in a corpus based on the input flags.
+Preprocess document or corpus based on the input flags.
 
 # List of Flags
 
@@ -389,6 +390,7 @@ Preprocess `doc` or all the documents in a corpus based on the input flags.
 * strip_html_tags
 
 # Example
+
 ```julia-repl
 julia> doc = StringDocument("This is a document of mine")
 StringDocument{String}("This is a document of mine", TextAnalysis.DocumentMetadata(Languages.English(), "Untitled Document", "Unknown Author", "Unknown Time"))
@@ -436,8 +438,8 @@ end
 """
     remove_whitespace(s::AbstractString)
 
-Squashes multiple whitespaces to a single one. And removes all leading and
-trailing whitespaces in a string.
+Squash multiple whitespaces to a single one.
+And remove all leading and trailing whitespaces.
 
 See also: [`remove_whitespace!`](@ref)
 """
@@ -445,13 +447,13 @@ remove_whitespace(s::AbstractString) = replace(strip(s), r"\s+"=>" ")
 
 
 """
-    remove_whitespace!(s::AbstractDocument)
+    remove_whitespace!(doc)
     remove_whitespace!(crps)
 
-Squashes multiple whitespaces to a single space. And removes all leading and
-trailing whitespaces in a StringDocument and Corpus.
+Squash multiple whitespaces to a single space.
+And remove all leading and trailing whitespaces in document or crps.
 
-Does no-op for NGramDocument and TokenDocument.
+Does no-op for `FileDocument`, `TokenDocument` or `NGramDocument`.
 """
 function remove_whitespace!(d::StringDocument)
     d.text = remove_whitespace(d.text)
@@ -470,7 +472,7 @@ end
 """
     remove_patterns(str, rex::Regex)
 
-Removes the patterns matched in `str` by the input Regex `rex`.
+Remove the part of str matched by rex.
 
 See also: [`remove_patterns!`](@ref)
 """
@@ -503,8 +505,9 @@ end
     remove_patterns!(doc, rex::Regex)
     remove_patterns!(crps, rex::Regex)
 
-Removes the patterns matched to `rex` in `doc`or each document in `crps`.
-`FileDocument` and Corpus containing these documents cannot be modified.
+Remove patterns matched by `rex` in document or Corpus.
+
+Does not modify `FileDocument` or Corpus containing `FileDocument`.
 """
 remove_patterns!(d::FileDocument, rex::Regex) = error("FileDocument cannot be modified")
 

--- a/src/sentiment.jl
+++ b/src/sentiment.jl
@@ -92,8 +92,7 @@ end
     model = SentimentAnalyzer(doc)
     model = SentimentAnalyzer(doc, handle_unknown)
 
-Predict sentiment of the input doc in range 0 to 1, 0 being least sentiment score and 1 being
-the highest.
+Predict sentiment of the input doc in range 0 to 1, 0 being least sentiment score and 1 being the highest.
 
 # Arguments
 -  doc              = Input Document for calculating document (`AbstractDocument` type)

--- a/src/sentiment.jl
+++ b/src/sentiment.jl
@@ -48,12 +48,12 @@ function get_sentiment(handle_unknown, ip::Array{T, 1}, weight, rwi) where T <: 
 	if ele in keys(rwi) && rwi[ele] <= size(weight[:embedding_1]["embedding_1"]["embeddings:0"])[2]   # there are only 5000 unique embeddings
             push!(res, rwi[ele])
 	else
-	    for words in handle_unknown(ele) 
+	    for words in handle_unknown(ele)
 		if words in keys(rwi) && rwi[words] <= size(weight[:embedding_1]["embedding_1"]["embeddings:0"])[2]
 		    push!(res, rwi[words])
 		end
-	    end	
-		
+	    end
+
 	end
     end
     return model(pad_sequences(res))[1]
@@ -67,7 +67,7 @@ struct SentimentModel
         # Only load Flux once it is actually needed
         global Flux
         Flux = Base.require(TextAnalysis, :Flux)
-        
+
         new(read_weights(), read_word_ids())
     end
 end
@@ -89,15 +89,16 @@ end
 
 
 """
- ```
- model = SentimentAnalyzer(doc)
- model = SentimentAnalyzer(doc, handle_unknown)
- ```
- Return sentiment of the input doc in range 0 to 1, 0 being least sentiment score and 1 being
- the highest:
-  -  doc              = Input Document for calculating document (AbstractDocument type)
-  -  handle_unknown   = A function for handling unknown words. Should return an array (default x->tuple())
- """
+    model = SentimentAnalyzer(doc)
+    model = SentimentAnalyzer(doc, handle_unknown)
+
+Returns the sentiment of the input doc in range 0 to 1, 0 being least sentiment score and 1 being
+the highest.
+
+# Arguments
+-  doc              = Input Document for calculating document (`AbstractDocument` type)
+-  handle_unknown   = A function for handling unknown words. Should return an array (default x->tuple())
+"""
 
 function(m::SentimentAnalyzer)(d::AbstractDocument, handle_unknown = x->tuple())
     m.model(handle_unknown, tokens(d))

--- a/src/sentiment.jl
+++ b/src/sentiment.jl
@@ -92,7 +92,7 @@ end
     model = SentimentAnalyzer(doc)
     model = SentimentAnalyzer(doc, handle_unknown)
 
-Returns the sentiment of the input doc in range 0 to 1, 0 being least sentiment score and 1 being
+Predict sentiment of the input doc in range 0 to 1, 0 being least sentiment score and 1 being
 the highest.
 
 # Arguments

--- a/src/stemmer.jl
+++ b/src/stemmer.jl
@@ -63,7 +63,7 @@ function release(stm::Stemmer)
 end
 
 """
-    stem(stemmer::Stemmer, str::AbstractString)
+    stem(stemmer::Stemmer, str)
     stem(stemmer::Stemmer, words::Array)
 
 Stem the input with the Stemming algorthm of `stemmer`.

--- a/src/stemmer.jl
+++ b/src/stemmer.jl
@@ -100,7 +100,7 @@ end
 """
     stemmer_for_document(doc)
 
-Search for an appropriate stemmer based on the language `doc`.
+Search for an appropriate stemmer based on the language of the document.
 """
 function stemmer_for_document(d::AbstractDocument)
     Stemmer(lowercase(Languages.english_name(language(d))))
@@ -111,6 +111,7 @@ end
     stem!(crps)
 
 Stems the document or documents in `crps` with a suitable stemmer.
+
 Stemming cannot be done for `FileDocument` and Corpus made of these type of documents.
 """
 function stem!(d::AbstractDocument)

--- a/src/stemmer.jl
+++ b/src/stemmer.jl
@@ -11,7 +11,7 @@ const KOI8_R        = "KOI8_R"
 """
     stemmer_types()
 
-Lists the stemmer algorithms loaded
+List all the stemmer algorithms loaded.
 """
 function stemmer_types()
     cptr = ccall((:sb_stemmer_list, libstemmer), Ptr{Ptr{UInt8}}, ())
@@ -66,7 +66,9 @@ end
     stem(stemmer::Stemmer, str::AbstractString)
     stem(stemmer::Stemmer, words::Array)
 
-Applies the Stemming algorthms on input string or array of words and returns the processed
+Stem the input with the Stemming algorthm of `stemmer`.
+
+See also: [`stem!`](@ref)
 """
 function stem(stemmer::Stemmer, bstr::AbstractString)
     sres = ccall((:sb_stemmer_stem, libstemmer),
@@ -98,7 +100,7 @@ end
 """
     stemmer_for_document(doc)
 
-Returns the appropriate stemmer, corresponding to the Language of the document.
+Search for an appropriate stemmer based on the language `doc`.
 """
 function stemmer_for_document(d::AbstractDocument)
     Stemmer(lowercase(Languages.english_name(language(d))))

--- a/src/stemmer.jl
+++ b/src/stemmer.jl
@@ -8,8 +8,11 @@ const ISO_8859_1    = "ISO_8859_1"
 const CP850         = "CP850"
 const KOI8_R        = "KOI8_R"
 
-##
-# lists the stemmer algorithms loaded
+"""
+    stemmer_types()
+
+Lists the stemmer algorithms loaded
+"""
 function stemmer_types()
     cptr = ccall((:sb_stemmer_list, libstemmer), Ptr{Ptr{UInt8}}, ())
     (C_NULL == cptr) && error("error getting stemmer types")
@@ -50,7 +53,7 @@ mutable struct Stemmer
     end
 end
 
-show(io::IO, stm::Stemmer) = println(io, "Stemmer algorithm:$(stm.alg) encoding:$(stm.enc)")
+Base.show(io::IO, stm::Stemmer) = println(io, "Stemmer algorithm:$(stm.alg) encoding:$(stm.enc)")
 
 function release(stm::Stemmer)
     (C_NULL == stm.cptr) && return
@@ -59,6 +62,12 @@ function release(stm::Stemmer)
     nothing
 end
 
+"""
+    stem(stemmer::Stemmer, str::AbstractString)
+    stem(stemmer::Stemmer, words::Array)
+
+Applies the Stemming algorthms on input string or array of words and returns the processed
+"""
 function stem(stemmer::Stemmer, bstr::AbstractString)
     sres = ccall((:sb_stemmer_stem, libstemmer),
                 Ptr{UInt8},
@@ -83,13 +92,25 @@ function stem(stemmer::Stemmer, words::Array)
     for idx in 1:l
         ret[idx] = stem(stemmer, words[idx])
     end
-    ret
+    return ret
 end
 
+"""
+    stemmer_for_document(doc)
+
+Returns the appropriate stemmer, corresponding to the Language of the document.
+"""
 function stemmer_for_document(d::AbstractDocument)
     Stemmer(lowercase(Languages.english_name(language(d))))
 end
 
+"""
+    stem!(doc)
+    stem!(crps)
+
+Stems the document or documents in `crps` with a suitable stemmer.
+Stemming cannot be done for `FileDocument` and Corpus made of these type of documents.
+"""
 function stem!(d::AbstractDocument)
     stemmer = stemmer_for_document(d)
     stem!(stemmer, d)

--- a/src/tf_idf.jl
+++ b/src/tf_idf.jl
@@ -2,6 +2,7 @@
     tf!(dtm::AbstractMatrix{Real}, tf::AbstractMatrix{AbstractFloat})
 
 Overwrite `tf` with the term frequency of the `dtm`.
+
 Works correctly if `dtm` and `tf` are same matrix.
 
 See also: [`tf`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
@@ -25,7 +26,8 @@ end
     tf!(dtm::SparseMatrixCSC{Real}, tf::SparseMatrixCSC{AbstractFloat})
 
 Overwrite `tf` with the term frequency of the `dtm`.
-It is assumed that `tf` has same nonzeros as `dtm`
+
+`tf` should have the has same nonzeros as `dtm`.
 
 See also: [`tf`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
 """
@@ -94,8 +96,8 @@ tf(dtm::SparseMatrixCSC{T}) where {T <: Real} =  tf!(dtm, similar(dtm, Float64))
 """
     tf_idf!(dtm::AbstractMatrix{Real}, tf_idf::AbstractMatrix{AbstractFloat})
 
-Overwrite `tf_idf` with the tf-idf (Term Frequency - Inverse Doc Frequency)
-of the `dtm`.
+Overwrite `tf_idf` with the tf-idf (Term Frequency - Inverse Doc Frequency) of the `dtm`.
+
 `dtm` and `tf-idf` must be matrices of same dimensions.
 
 See also: [`tf`](@ref), [`tf!`](@ref) , [`tf_idf`](@ref)
@@ -124,6 +126,7 @@ end
     tf_idf!(dtm::SparseMatrixCSC{Real}, tfidf::SparseMatrixCSC{AbstractFloat})
 
 Overwrite `tfidf` with the tf-idf (Term Frequency - Inverse Doc Frequency) of the `dtm`.
+
 The arguments must have same number of nonzeros.
 
 See also: [`tf`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
@@ -171,8 +174,7 @@ tf_idf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf_idf!(dtm, dtm)
     tf(::SparseMatrixCSC{T}) where {T <: Real}
     tf(::Matrix{T}) where {T <: Real}
 
-Compute `tf-idf` value (Term Frequency - Inverse Document Frequency)
-for the input.
+Compute `tf-idf` value (Term Frequency - Inverse Document Frequency) for the input.
 
 In many cases, raw word counts are not appropriate for use because:
 

--- a/src/tf_idf.jl
+++ b/src/tf_idf.jl
@@ -56,8 +56,8 @@ tf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf!(dtm, dtm)
 
 """
     tf(dtm::DocumentTermMatrix)
-    tf(dtm::SparseMatrixCSC{T}) where {T <: Real}
-    tf(dtm::Matrix{T}) where {T <: Real}
+    tf(dtm::SparseMatrixCSC{Real})
+    tf(dtm::Matrix{Real})
 
 Compute the `term-frequency` of the input.
 
@@ -171,8 +171,8 @@ tf_idf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf_idf!(dtm, dtm)
 
 """
     tf(dtm::DocumentTermMatrix)
-    tf(dtm::SparseMatrixCSC{T}) where {T <: Real}
-    tf(dtm::Matrix{T}) where {T <: Real}
+    tf(dtm::SparseMatrixCSC{Real})
+    tf(dtm::Matrix{Real})
 
 Compute `tf-idf` value (Term Frequency - Inverse Document Frequency) for the input.
 

--- a/src/tf_idf.jl
+++ b/src/tf_idf.jl
@@ -1,7 +1,7 @@
 """
     tf!(dtm::AbstractMatrix{Real}, tf::AbstractMatrix{AbstractFloat})
 
-Overwrites `tf` with the term frequency of the `dtm`.
+Overwrite `tf` with the term frequency of the `dtm`.
 Works correctly if `dtm` and `tf` are same matrix.
 
 See also: [`tf`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
@@ -24,7 +24,7 @@ end
 """
     tf!(dtm::SparseMatrixCSC{Real}, tf::SparseMatrixCSC{AbstractFloat})
 
-Overwrites `tf` with the term frequency of the `dtm`.
+Overwrite `tf` with the term frequency of the `dtm`.
 It is assumed that `tf` has same nonzeros as `dtm`
 
 See also: [`tf`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
@@ -57,8 +57,7 @@ tf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf!(dtm, dtm)
     tf(::SparseMatrixCSC{T}) where {T <: Real}
     tf(::Matrix{T}) where {T <: Real}
 
-Returns the `term-frequency` for the input, telling us
-what proportion of a document is defined by each term.
+Compute the `term-frequency` of the input.
 
 # Example
 
@@ -95,8 +94,9 @@ tf(dtm::SparseMatrixCSC{T}) where {T <: Real} =  tf!(dtm, similar(dtm, Float64))
 """
     tf_idf!(dtm::AbstractMatrix{Real}, tf_idf::AbstractMatrix{AbstractFloat})
 
-Overwrites `tf_idf` with the tf-idf (Term Frequency - Inverse Doc Frequency)
-of the `dtm`. Works correctly if `dtm` and `tf-idf` are same matrix.
+Overwrite `tf_idf` with the tf-idf (Term Frequency - Inverse Doc Frequency)
+of the `dtm`.
+`dtm` and `tf-idf` must be matrices of same dimensions.
 
 See also: [`tf`](@ref), [`tf!`](@ref) , [`tf_idf`](@ref)
 """
@@ -123,8 +123,8 @@ end
 """
     tf_idf!(dtm::SparseMatrixCSC{Real}, tfidf::SparseMatrixCSC{AbstractFloat})
 
-Overwrites `tfidf` with the tf-idf (Term Frequency - Inverse Doc Frequency) of the
-`dtm`. It is assumed that both the input Sparse Matrices have the same nonzeros.
+Overwrite `tfidf` with the tf-idf (Term Frequency - Inverse Doc Frequency) of the `dtm`.
+The arguments must have same number of nonzeros.
 
 See also: [`tf`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
 """
@@ -157,7 +157,7 @@ end
 """
     tf_idf!(dtm)
 
-Returns the tf-idf value of the input `DocumentTermMatrix`
+Compute tf-idf for `dtm`
 """
 tf_idf!(dtm::AbstractMatrix{T}) where {T <: Real} = tf_idf!(dtm, dtm)
 
@@ -171,9 +171,8 @@ tf_idf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf_idf!(dtm, dtm)
     tf(::SparseMatrixCSC{T}) where {T <: Real}
     tf(::Matrix{T}) where {T <: Real}
 
-Returns the `tf-idf` value (Term Frequency - Inverse Document Frequency)
+Compute `tf-idf` value (Term Frequency - Inverse Document Frequency)
 for the input.
-
 
 In many cases, raw word counts are not appropriate for use because:
 

--- a/src/tf_idf.jl
+++ b/src/tf_idf.jl
@@ -55,9 +55,9 @@ tf!(dtm::AbstractMatrix{T}) where {T <: Real} = tf!(dtm, dtm)
 tf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf!(dtm, dtm)
 
 """
-    tf(::DocumentTermMatrix)
-    tf(::SparseMatrixCSC{T}) where {T <: Real}
-    tf(::Matrix{T}) where {T <: Real}
+    tf(dtm::DocumentTermMatrix)
+    tf(dtm::SparseMatrixCSC{T}) where {T <: Real}
+    tf(dtm::Matrix{T}) where {T <: Real}
 
 Compute the `term-frequency` of the input.
 
@@ -170,9 +170,9 @@ tf_idf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf_idf!(dtm, dtm)
 #tf_idf!(dtm::DocumentTermMatrix) = tf_idf!(dtm.dtm)
 
 """
-    tf(::DocumentTermMatrix)
-    tf(::SparseMatrixCSC{T}) where {T <: Real}
-    tf(::Matrix{T}) where {T <: Real}
+    tf(dtm::DocumentTermMatrix)
+    tf(dtm::SparseMatrixCSC{T}) where {T <: Real}
+    tf(dtm::Matrix{T}) where {T <: Real}
 
 Compute `tf-idf` value (Term Frequency - Inverse Document Frequency) for the input.
 

--- a/src/tf_idf.jl
+++ b/src/tf_idf.jl
@@ -1,21 +1,11 @@
-##############################################################################
-#
-# TF
-#
-##############################################################################
+"""
+    tf!(dtm::AbstractMatrix{Real}, tf::AbstractMatrix{AbstractFloat})
 
-tf(dtm::Matrix{T}) where {T <: Real} = tf!(dtm, Array{Float64}(undef, size(dtm)...))
+Overwrites `tf` with the term frequency of the `dtm`.
+Works correctly if `dtm` and `tf` are same matrix.
 
-tf(dtm::SparseMatrixCSC{T}) where {T <: Real} =  tf!(dtm, similar(dtm, Float64))
-
-tf!(dtm::AbstractMatrix{T}) where {T <: Real} = tf!(dtm, dtm)
-
-tf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf!(dtm, dtm)
-
-tf(dtm::DocumentTermMatrix) = tf(dtm.dtm)
-
-# The second Matrix will be overwritten with the result
-# Will work correctly if dtm and tfidf are the same matrix
+See also: [`tf`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
+"""
 function tf!(dtm::AbstractMatrix{T1}, tf::AbstractMatrix{T2}) where {T1 <: Real, T2 <: AbstractFloat}
     n, p = size(dtm)
 
@@ -31,7 +21,14 @@ function tf!(dtm::AbstractMatrix{T1}, tf::AbstractMatrix{T2}) where {T1 <: Real,
     return tf
 end
 
-# assumes second matrix has same nonzeros as first one
+"""
+    tf!(dtm::SparseMatrixCSC{Real}, tf::SparseMatrixCSC{AbstractFloat})
+
+Overwrites `tf` with the term frequency of the `dtm`.
+It is assumed that `tf` has same nonzeros as `dtm`
+
+See also: [`tf`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
+"""
 function tf!(dtm::SparseMatrixCSC{T}, tf::SparseMatrixCSC{F}) where {T <: Real, F <: AbstractFloat}
     rows = rowvals(dtm)
     dtmvals = nonzeros(dtm)
@@ -48,31 +45,61 @@ function tf!(dtm::SparseMatrixCSC{T}, tf::SparseMatrixCSC{F}) where {T <: Real, 
           tfvals[j] = dtmvals[j] / max(words_in_documents[row], one(T))
        end
     end
-    tf
+    return tf
 end
 
-##############################################################################
-#
-# TF-IDF
-#
-##############################################################################
+tf!(dtm::AbstractMatrix{T}) where {T <: Real} = tf!(dtm, dtm)
 
-tf_idf(dtm::Matrix{T}) where {T <: Real} = tf_idf!(dtm, Array{Float64}(undef, size(dtm)...))
+tf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf!(dtm, dtm)
 
-tf_idf(dtm::SparseMatrixCSC{T}) where {T <: Real} =  tf_idf!(dtm, similar(dtm, Float64))
+"""
+    tf(::DocumentTermMatrix)
+    tf(::SparseMatrixCSC{T}) where {T <: Real}
+    tf(::Matrix{T}) where {T <: Real}
 
-tf_idf!(dtm::AbstractMatrix{T}) where {T <: Real} = tf_idf!(dtm, dtm)
+Returns the `term-frequency` for the input, telling us
+what proportion of a document is defined by each term.
 
-tf_idf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf_idf!(dtm, dtm)
+# Example
 
-tf_idf(dtm::DocumentTermMatrix) = tf_idf(dtm.dtm)
+```julia-repl
+julia> crps = Corpus([StringDocument("To be or not to be"),
+              StringDocument("To become or not to become")])
 
-# This does not make sense, since DocumentTermMatrix is based on an array of integers
-#tf_idf!(dtm::DocumentTermMatrix) = tf_idf!(dtm.dtm)
+julia> update_lexicon!(crps)
 
+julia> m = DocumentTermMatrix(crps)
 
-# The second Matrix will be overwritten with the result
-# Will work correctly if dtm and tfidf are the same matrix
+julia> tf(m)
+2×6 SparseArrays.SparseMatrixCSC{Float64,Int64} with 10 stored entries:
+  [1, 1]  =  0.166667
+  [2, 1]  =  0.166667
+  [1, 2]  =  0.333333
+  [2, 3]  =  0.333333
+  [1, 4]  =  0.166667
+  [2, 4]  =  0.166667
+  [1, 5]  =  0.166667
+  [2, 5]  =  0.166667
+  [1, 6]  =  0.166667
+  [2, 6]  =  0.166667
+```
+
+See also: [`tf!`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
+"""
+tf(dtm::DocumentTermMatrix) = tf(dtm.dtm)
+
+tf(dtm::Matrix{T}) where {T <: Real} = tf!(dtm, Array{Float64}(undef, size(dtm)...))
+
+tf(dtm::SparseMatrixCSC{T}) where {T <: Real} =  tf!(dtm, similar(dtm, Float64))
+
+"""
+    tf_idf!(dtm::AbstractMatrix{Real}, tf_idf::AbstractMatrix{AbstractFloat})
+
+Overwrites `tf_idf` with the tf-idf (Term Frequency - Inverse Doc Frequency)
+of the `dtm`. Works correctly if `dtm` and `tf-idf` are same matrix.
+
+See also: [`tf`](@ref), [`tf!`](@ref) , [`tf_idf`](@ref)
+"""
 function tf_idf!(dtm::AbstractMatrix{T1}, tfidf::AbstractMatrix{T2}) where {T1 <: Real, T2 <: AbstractFloat}
     n, p = size(dtm)
 
@@ -93,7 +120,14 @@ function tf_idf!(dtm::AbstractMatrix{T1}, tfidf::AbstractMatrix{T2}) where {T1 <
     return tfidf
 end
 
-# sparse version
+"""
+    tf_idf!(dtm::SparseMatrixCSC{Real}, tfidf::SparseMatrixCSC{AbstractFloat})
+
+Overwrites `tfidf` with the tf-idf (Term Frequency - Inverse Doc Frequency) of the
+`dtm`. It is assumed that both the input Sparse Matrices have the same nonzeros.
+
+See also: [`tf`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
+"""
 function tf_idf!(dtm::SparseMatrixCSC{T}, tfidf::SparseMatrixCSC{F}) where {T <: Real, F <: AbstractFloat}
     rows = rowvals(dtm)
     dtmvals = nonzeros(dtm)
@@ -117,5 +151,65 @@ function tf_idf!(dtm::SparseMatrixCSC{T}, tfidf::SparseMatrixCSC{F}) where {T <:
        end
     end
 
-    tfidf
+    return tfidf
 end
+
+"""
+    tf_idf!(dtm)
+
+Returns the tf-idf value of the input `DocumentTermMatrix`
+"""
+tf_idf!(dtm::AbstractMatrix{T}) where {T <: Real} = tf_idf!(dtm, dtm)
+
+tf_idf!(dtm::SparseMatrixCSC{T}) where {T <: Real} = tf_idf!(dtm, dtm)
+
+# This does not make sense, since DocumentTermMatrix is based on an array of integers
+#tf_idf!(dtm::DocumentTermMatrix) = tf_idf!(dtm.dtm)
+
+"""
+    tf(::DocumentTermMatrix)
+    tf(::SparseMatrixCSC{T}) where {T <: Real}
+    tf(::Matrix{T}) where {T <: Real}
+
+Returns the `tf-idf` value (Term Frequency - Inverse Document Frequency)
+for the input.
+
+
+In many cases, raw word counts are not appropriate for use because:
+
+- Some documents are longer than other documents
+- Some words are more frequent than other words
+
+A simple workaround this can be done by performing `TF-IDF` on a `DocumentTermMatrix`
+
+# Example
+
+```julia-repl
+julia> crps = Corpus([StringDocument("To be or not to be"),
+              StringDocument("To become or not to become")])
+
+julia> update_lexicon!(crps)
+
+julia> m = DocumentTermMatrix(crps)
+
+julia> tf_idf(m)
+2×6 SparseArrays.SparseMatrixCSC{Float64,Int64} with 10 stored entries:
+  [1, 1]  =  0.0
+  [2, 1]  =  0.0
+  [1, 2]  =  0.231049
+  [2, 3]  =  0.231049
+  [1, 4]  =  0.0
+  [2, 4]  =  0.0
+  [1, 5]  =  0.0
+  [2, 5]  =  0.0
+  [1, 6]  =  0.0
+  [2, 6]  =  0.0
+```
+
+See also: [`tf!`](@ref), [`tf_idf`](@ref), [`tf_idf!`](@ref)
+"""
+tf_idf(dtm::DocumentTermMatrix) = tf_idf(dtm.dtm)
+
+tf_idf(dtm::SparseMatrixCSC{T}) where {T <: Real} =  tf_idf!(dtm, similar(dtm, Float64))
+
+tf_idf(dtm::Matrix{T}) where {T <: Real} = tf_idf!(dtm, Array{Float64}(undef, size(dtm)...))

--- a/src/tokenizer.jl
+++ b/src/tokenizer.jl
@@ -1,10 +1,10 @@
 """
     tokenize(language, str)
 
-Splits Strings into words and other tokens such as puntuation.
-The output may vary as per the default tokenizer of WordTokenizers.jl
+Split `str` into words and other tokens such as punctuation.
 
 # Example
+
 ```julia-repl
 julia> tokenize(Languages.English(), "Too foo words!")
 4-element Array{String,1}:
@@ -13,6 +13,8 @@ julia> tokenize(Languages.English(), "Too foo words!")
  "words"
  "!"
 ```
+
+See also: [`sentence_tokenize`](@ref)
 """
 tokenize(lang::S, s::T) where {S <: Language, T <: AbstractString} = WordTokenizers.tokenize(s)
 
@@ -20,7 +22,7 @@ tokenize(lang::S, s::T) where {S <: Language, T <: AbstractString} = WordTokeniz
 """
     sentence_tokenize(language, str)
 
-Splits Strings into sentences.
+Split `str` into sentences.
 
 # Example
 ```julia-repl
@@ -29,5 +31,7 @@ julia> sentence_tokenize(Languages.English(), "Here are few words! I am Foo Bar.
  "Here are few words!"
  "I am Foo Bar."
 ```
+
+See also: [`tokenize`](@ref)
 """
 sentence_tokenize(lang::S, s::T) where {S <: Language, T<:AbstractString} = WordTokenizers.split_sentences(s)

--- a/src/tokenizer.jl
+++ b/src/tokenizer.jl
@@ -1,9 +1,33 @@
-##############################################################################
-#
-# Split string into tokens on whitespace
-#
-##############################################################################
+"""
+    tokenize(language, str)
 
+Splits Strings into words and other tokens such as puntuation.
+The output may vary as per the default tokenizer of WordTokenizers.jl
+
+# Example
+```julia-repl
+julia> tokenize(Languages.English(), "Too foo words!")
+4-element Array{String,1}:
+ "Too"
+ "foo"
+ "words"
+ "!"
+```
+"""
 tokenize(lang::S, s::T) where {S <: Language, T <: AbstractString} = WordTokenizers.tokenize(s)
 
+
+"""
+    sentence_tokenize(language, str)
+
+Splits Strings into sentences.
+
+# Example
+```julia-repl
+julia> sentence_tokenize(Languages.English(), "Here are few words! I am Foo Bar.")
+2-element Array{SubString{String},1}:
+ "Here are few words!"
+ "I am Foo Bar."
+```
+"""
 sentence_tokenize(lang::S, s::T) where {S <: Language, T<:AbstractString} = WordTokenizers.split_sentences(s)


### PR DESCRIPTION
I am adding docstrings. I will work my way starting with the lexicographically largest down to smallest  based on file names, (i.e. in the following order), so that @aquatiko can work in lexigraphical order in #147 , preventing overlaps.
- [X] tokenizer.jl
- [X] tf_tdf.jl
- [X] summarizer.jl (#154 )
- [X] show.jl (#155)
- [X] sentiment.jl
- [X] stemmer.jl
- [X] preprocessing.jl
- [X] ngramizer.jl
- [X] metadata.jl
- [X] lsa.jl
- [X] lda.jl 
- [X] hash.jl
- [X] dtm.jl
- [X] bayes.jl (#151 )

**Edit:** closes #146 