### PR TITLE
Fix deprecations in show.jl

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -1,8 +1,8 @@
-show(io::IO, d::AbstractDocument) = print(io, "A $(typeof(d))")
-show(io::IO, crps::Corpus) = print(io, "A Corpus")
-show(io::IO, dtm::DocumentTermMatrix) = print(io, "A DocumentTermMatrix")
+Base.show(io::IO, d::AbstractDocument) = print(io, "A $(typeof(d))")
+Base.show(io::IO, crps::Corpus) = print(io, "A Corpus")
+Base.show(io::IO, dtm::DocumentTermMatrix) = print(io, "A DocumentTermMatrix")
 
-function summary(d::AbstractDocument)
+function Base.summary(d::AbstractDocument)
     o = ""
     o *= "A $(typeof(d))\n"
     o *= " * Language: $(language(d))\n"
@@ -19,7 +19,7 @@ function summary(d::AbstractDocument)
     return o
 end
 
-function summary(crps::Corpus)
+function Base.summary(crps::Corpus)
     n = length(crps.documents)
     n_s = sum(map(d -> typeof(d) == StringDocument, crps.documents))
     n_f = sum(map(d -> typeof(d) == FileDocument, crps.documents))
@@ -36,7 +36,7 @@ function summary(crps::Corpus)
     return o
 end
 
-function summary(dtm::DocumentTermMatrix)
+function Base.summary(dtm::DocumentTermMatrix)
     n, p = size(dtm.dtm)
     @sprintf "A %dx%d DocumentTermMatrix" n p
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,9 +1,3 @@
-##############################################################################
-#
-# Basic printing of TextAnalysis types
-#
-##############################################################################
-
 show(io::IO, d::AbstractDocument) = print(io, "A $(typeof(d))")
 show(io::IO, crps::Corpus) = print(io, "A Corpus")
 show(io::IO, dtm::DocumentTermMatrix) = print(io, "A DocumentTermMatrix")
@@ -21,10 +15,11 @@ function summary(d::AbstractDocument)
     o *= " * Title: $(title(d))\n"
     o *= " * Author: $(author(d))\n"
     o *= " * Timestamp: $(timestamp(d))\n"
-    if contains(Any[TokenDocument, NGramDocument], typeof(d))
+
+    if typeof(d) ∈ [TokenDocument, NGramDocument]
         o *= " * Snippet: ***SAMPLE TEXT NOT AVAILABLE***"
     else
-        sample_text = replace(text(d)[1:50], r"\s+", " ")
+        sample_text = replace(text(d)[1:min(50, length(text(d)))], r"\s+", " ")
         o *= " * Snippet: $(sample_text)"
     end
     return o
@@ -51,12 +46,6 @@ function summary(dtm::DocumentTermMatrix)
     n, p = size(dtm.dtm)
     @sprintf "A %dx%d DocumentTermMatrix" n p
 end
-
-##############################################################################
-#
-# In the REPL, show the summary by default
-#
-##############################################################################
 
 repl_show(io::IO, d::AbstractDocument) = print(io, summary(d))
 repl_show(io::IO, crps::Corpus) = print(io, summary(crps))

--- a/src/show.jl
+++ b/src/show.jl
@@ -2,12 +2,6 @@ show(io::IO, d::AbstractDocument) = print(io, "A $(typeof(d))")
 show(io::IO, crps::Corpus) = print(io, "A Corpus")
 show(io::IO, dtm::DocumentTermMatrix) = print(io, "A DocumentTermMatrix")
 
-##############################################################################
-#
-# Pretty printing of TextAnalysis types
-#
-##############################################################################
-
 function summary(d::AbstractDocument)
     o = ""
     o *= "A $(typeof(d))\n"
@@ -19,7 +13,7 @@ function summary(d::AbstractDocument)
     if typeof(d) ∈ [TokenDocument, NGramDocument]
         o *= " * Snippet: ***SAMPLE TEXT NOT AVAILABLE***"
     else
-        sample_text = replace(text(d)[1:min(50, length(text(d)))], r"\s+", " ")
+        sample_text = replace(text(d)[1:min(50, length(text(d)))], r"\s+" => " ")
         o *= " * Snippet: $(sample_text)"
     end
     return o

--- a/src/show.jl
+++ b/src/show.jl
@@ -38,7 +38,8 @@ end
 
 function Base.summary(dtm::DocumentTermMatrix)
     n, p = size(dtm.dtm)
-    @sprintf "A %dx%d DocumentTermMatrix" n p
+    o = "A $n X $p DocumentTermMatrix"
+    return o
 end
 
 repl_show(io::IO, d::AbstractDocument) = print(io, summary(d))

--- a/src/show.jl
+++ b/src/show.jl
@@ -21,10 +21,10 @@ end
 
 function Base.summary(crps::Corpus)
     n = length(crps.documents)
-    n_s = sum(map(d -> typeof(d) == StringDocument, crps.documents))
+    n_s = sum(map(d -> typeof(d) == StringDocument{String}, crps.documents))
     n_f = sum(map(d -> typeof(d) == FileDocument, crps.documents))
-    n_t = sum(map(d -> typeof(d) == TokenDocument, crps.documents))
-    n_ng = sum(map(d -> typeof(d) == NGramDocument, crps.documents))
+    n_t = sum(map(d -> typeof(d) == TokenDocument{String}, crps.documents))
+    n_ng = sum(map(d -> typeof(d) == NGramDocument{String}, crps.documents))
     o = ""
     o *= "A Corpus with $n documents:\n"
     o *= " * $n_s StringDocument's\n"
@@ -42,6 +42,6 @@ function Base.summary(dtm::DocumentTermMatrix)
     return o
 end
 
-repl_show(io::IO, d::AbstractDocument) = print(io, summary(d))
-repl_show(io::IO, crps::Corpus) = print(io, summary(crps))
-repl_show(io::IO, dtm::DocumentTermMatrix) = print(io, summary(dtm))
+Base.show(io::IO, ::MIME"text/plain", d::AbstractDocument) = print(io, summary(d))
+Base.show(io::IO, ::MIME"text/plain", crps::Corpus) = print(io, summary(crps))
+Base.show(io::IO, ::MIME"text/plain", dtm::DocumentTermMatrix) = print(io, summary(dtm))


### PR DESCRIPTION
Minor deprecations and bugs (similar to #153) fixed.

The function `summary` in show.jl ([source](https://github.com/JuliaText/TextAnalysis.jl/blob/3b046d2c205d1525b2acaf3c2f66b52ce69bfad5/src/show.jl#L17)) is named similar to [Base.summary](https://docs.julialang.org/en/v1/base/io-network/#Base.summary). 

@aviks  What should I rename this to? Or should I extend Base.summary to support  `AbstractDocument`, `Corpus` types? 
