### PR TITLE
Throw appropriate error for pad_sequence input of length > maxlen

### DIFF
--- a/src/sentiment.jl
+++ b/src/sentiment.jl
@@ -8,7 +8,10 @@ function pad_sequences(l, maxlen=500)
             push!(res, ele)
         end
         return res
-    end
+    
+    else
+        print("Not Possible to have string length greater than maximum length")
+	end
 end
 
 function read_weights(filename=sentiment_weights)


### PR DESCRIPTION
Displays an error message in case length of string is greater than the defined maximum length.