### PR TITLE
bug fix in get_sentiment function

### DIFF
--- a/src/sentiment.jl
+++ b/src/sentiment.jl
@@ -43,7 +43,7 @@ function get_sentiment(handle_unknown, ip::Array{T, 1}, weight, rwi) where T <: 
     end
     res = Array{Int, 1}()
     for ele in ip
-	if ele in keys(rwi) && rwi[ele] <= size(weight[:embedding_1]["embedding_1"]["embeddings:0"])[2]   # there are only 5000 unique embeddings
+	if ele in keys(rwi) && rwi[ele] <= ( size(weight[:embedding_1]["embedding_1"]["embeddings:0"])[2] - 1 )  # there are only 5000 unique embeddings (padding corresponds to default index-1)
             push!(res, rwi[ele])
 	else
 	    for words in handle_unknown(ele)


### PR DESCRIPTION
As mentioned #205 and #187
Bug fixed in sentiment function
In file sentiment_weights we are having having 32×5000 matrices with index-1 is default pad token embedding
But here
in src/sentiment.jl
`if ele in keys(rwi) && rwi[ele] <= ( size(weight[:embedding_1]["embedding_1"]["embeddings:0"])[2] ) # there are only 5000 unique embeddings` -
 we are allowing 5000 unique embedding excluding padding which implies 5001 unique embedding but we have only 32×5000 weight.
I am not sure about training process may be we are training on only first 5000 element with padding token then replacing above line will work. 