### PR TITLE
export NaiveBayesClassifier

### DIFF
--- a/src/TextAnalysis.jl
+++ b/src/TextAnalysis.jl
@@ -58,6 +58,7 @@ module TextAnalysis
     export strip_numbers, strip_non_letters, strip_indefinite_articles, strip_definite_articles, strip_articles
     export strip_prepositions, strip_pronouns, strip_stopwords, strip_sparse_terms, strip_frequent_terms, strip_html_tags
 
+    export NaiveBayesClassifier
     export SentimentAnalyzer
     export tag_scheme!
     export rouge_l_summary, rouge_l_sentence, rouge_n


### PR DESCRIPTION
fixes #216

I'm not exactly sure why, but the example code in the documentation doesn't run as seen in issue #216. I was trying to get it running and apparently exporting it on the main module is enough. Please tell me if you believe anything else should be added to this PR. 👍 