### PR TITLE
fix Project.toml, add Tables compat entry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 WordTokenizers = "796a5d58-b03d-544a-977e-18100b691f6e"
 
 [compat]
-DataFrames = "0.21, 0.22"
+Tables = "1.2"
 DataStructures = "0.17, 0.18"
 JSON = "0.21"
 Languages = "0.4"


### PR DESCRIPTION
Tables.jl compat entry was missing because of which caused registration checks to fail [here](https://github.com/JuliaRegistries/General/pull/26634).

This adds compat entry for Tables.jl and removes that of DataFrames. Ref: https://github.com/JuliaText/TextAnalysis.jl/pull/240