### PR TITLE
Update coom.jl

### DIFF
--- a/src/coom.jl
+++ b/src/coom.jl
@@ -145,7 +145,7 @@ function CooMatrix{T}(doc; window::Int=5, normalize::Bool=true) where T<:Abstrac
     CooMatrix{T}(doc, terms, window=window, normalize=normalize)
 end
 
-CooMatrix(doc; window::Int=5, normalize::Bool=true) where T<:AbstractFloat =
+CooMatrix(doc; window::Int=5, normalize::Bool=true) =
     CooMatrix{Float64}(doc, window=window, normalize=normalize)
 
 """


### PR DESCRIPTION
Remove unused type due to installation warning

```
TextAnalysis [a2db99b7-8b79-58f8-94bf-bbc811eef33d]
│  WARNING: method definition for #CooMatrix#80 at /home/opto/.julia/packages/TextAnalysis/Exn5l/src/coom.jl:148 declares type variable T but does not use it.
```